### PR TITLE
Fix duplicate elimination in language selection

### DIFF
--- a/app/src/main/java/com/vrem/wifianalyzer/settings/LanguageCountry.java
+++ b/app/src/main/java/com/vrem/wifianalyzer/settings/LanguageCountry.java
@@ -38,8 +38,8 @@ public class LanguageCountry {
         return new ArrayList<LanguageCountry>(CollectionUtils.collect(Arrays.asList(LocaleType.values()), new ToLanguageCountry()));
     }
 
-    public String getCountryCode() {
-        return localeType.getLocale().getCountry();
+    public String getLanguageCode() {
+        return localeType.getLocale().toString();
     }
 
     public String getLanguageName() {

--- a/app/src/main/java/com/vrem/wifianalyzer/settings/LanguagePreference.java
+++ b/app/src/main/java/com/vrem/wifianalyzer/settings/LanguagePreference.java
@@ -53,7 +53,7 @@ public class LanguagePreference extends CustomPreference {
     public static String getDefault(@NonNull Context context) {
         Resources resources = context.getResources();
         Configuration configuration = resources.getConfiguration();
-        return getLocale(configuration).getCountry();
+        return getLocale(configuration).toString();
     }
 
     @SuppressWarnings("deprecation")
@@ -68,14 +68,14 @@ public class LanguagePreference extends CustomPreference {
     private static class ToDataLanguage implements Transformer<LanguageCountry, Data> {
         @Override
         public Data transform(LanguageCountry input) {
-            return new Data(input.getCountryCode(), input.getLanguageName());
+            return new Data(input.getLanguageCode(), input.getLanguageName());
         }
     }
 
     private static class LanguageCountryComparator implements Comparator<LanguageCountry> {
         @Override
         public int compare(LanguageCountry o1, LanguageCountry o2) {
-            return o1.getCountryCode().compareTo(o2.getCountryCode());
+            return o1.getLanguageCode().compareTo(o2.getLanguageCode());
         }
     }
 }

--- a/app/src/main/java/com/vrem/wifianalyzer/settings/LocaleType.java
+++ b/app/src/main/java/com/vrem/wifianalyzer/settings/LocaleType.java
@@ -42,9 +42,9 @@ public enum LocaleType {
         return locale;
     }
 
-    public static LocaleType fromString(String countryCode) {
+    public static LocaleType fromString(String language) {
         for (LocaleType localeType : LocaleType.values()) {
-            if (localeType.getLocale().getCountry().equals(countryCode)) {
+            if (localeType.getLocale().toString().equals(language)) {
                 return localeType;
             }
         }

--- a/app/src/test/java/com/vrem/wifianalyzer/settings/LanguagePreferenceTest.java
+++ b/app/src/test/java/com/vrem/wifianalyzer/settings/LanguagePreferenceTest.java
@@ -74,8 +74,8 @@ public class LanguagePreferenceTest {
         // validate
         int expectedSize = countries.size();
         assertEquals(expectedSize, actual.length);
-        assertEquals(countries.get(0).getCountryCode(), actual[0]);
-        assertEquals(countries.get(expectedSize - 1).getCountryCode(), actual[expectedSize - 1]);
+        assertEquals(countries.get(0).getLanguageCode(), actual[0]);
+        assertEquals(countries.get(expectedSize - 1).getLanguageCode(), actual[expectedSize - 1]);
     }
 
     private static class LanguageCountryComparator implements Comparator<LanguageCountry> {
@@ -83,7 +83,7 @@ public class LanguagePreferenceTest {
         public int compare(LanguageCountry lhs, LanguageCountry rhs) {
             return new CompareToBuilder()
                 .append(lhs.getLanguageName(), rhs.getLanguageName())
-                .append(lhs.getCountryCode(), rhs.getCountryCode())
+                .append(lhs.getLanguageCode(), rhs.getLanguageCode())
                 .toComparison();
         }
     }

--- a/app/src/test/java/com/vrem/wifianalyzer/settings/LocaleTypeTest.java
+++ b/app/src/test/java/com/vrem/wifianalyzer/settings/LocaleTypeTest.java
@@ -36,7 +36,7 @@ public class LocaleTypeTest {
         // setup
         LocaleType expected = LocaleType.GERMAN;
         // execute
-        LocaleType actual = LocaleType.fromString("DE");
+        LocaleType actual = LocaleType.fromString("de_DE");
         // validate
         assertEquals(actual, expected);
         assertEquals(actual.getLocale(), expected.getLocale());

--- a/app/src/test/java/com/vrem/wifianalyzer/settings/SettingsTest.java
+++ b/app/src/test/java/com/vrem/wifianalyzer/settings/SettingsTest.java
@@ -347,8 +347,8 @@ public class SettingsTest {
         when(context.getResources()).thenReturn(resources);
         when(resources.getConfiguration()).thenReturn(configuration);
         withConfigurationLocale(Locale.UK);
-        String defaultValue = Locale.UK.getCountry();
-        String expected = Locale.US.getCountry();
+        String defaultValue = Locale.UK.toString();
+        String expected = Locale.US.toString();
 
         when(repository.getString(R.string.language_key, defaultValue)).thenReturn(expected);
         // execute
@@ -368,8 +368,8 @@ public class SettingsTest {
         when(context.getResources()).thenReturn(resources);
         when(resources.getConfiguration()).thenReturn(configuration);
         withConfigurationLocale(Locale.UK);
-        String defaultValue = Locale.UK.getCountry();
-        String expected = Locale.KOREA.getCountry();
+        String defaultValue = Locale.UK.toString();
+        String expected = Locale.KOREA.toString();
 
         when(repository.getString(R.string.language_key, defaultValue)).thenReturn(expected);
         // execute


### PR DESCRIPTION
Instead of using the Locale.getCountry() string as the stored preference
for the user's language selection, we should probably use
Locale.toString(). For example, this would means storing de_DE instead
of DE.

Otherwise, if the system Locale has the same country as a translation,
but a different language (something like en_DE), the actual German
translation (de_DE) is not shown in the preference list as it is
identified as a duplicate by the comparator used by
LanguagePreference.getData().

Fix it by replacing .getCountry() with .toString() at the relevant
places.