### PR TITLE
System Theme option

### DIFF
--- a/app/src/main/java/com/vrem/wifianalyzer/settings/ThemeStyle.java
+++ b/app/src/main/java/com/vrem/wifianalyzer/settings/ThemeStyle.java
@@ -25,7 +25,8 @@ import com.vrem.wifianalyzer.R;
 
 public enum ThemeStyle {
     DARK(R.style.ThemeDark, R.style.ThemeDarkNoActionBar),
-    LIGHT(R.style.ThemeLight, R.style.ThemeLightNoActionBar);
+    LIGHT(R.style.ThemeLight, R.style.ThemeLightNoActionBar),
+    SYSTEM(R.style.ThemeSystem, R.style.ThemeSystemNoActionBar);
 
     private final int theme;
     private final int themeNoActionBar;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -97,11 +97,13 @@
     <string-array name="theme_index_array" translatable="false">
         <item>0</item>
         <item>1</item>
+        <item>2</item>
     </string-array>
 
     <string-array name="theme_array">
         <item>Dark</item>
         <item>Light</item>
+        <item>System</item>
     </string-array>
 
     <string-array name="graph_colors" translatable="false">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -18,6 +18,15 @@
   -->
 
 <resources>
+  
+  <style name="ThemeSystem" parent="Theme.AppCompat.DayNight">
+
+    </style>
+
+    <style name="ThemeSystemNoActionBar" parent="ThemeSystem">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
 
     <style name="ThemeDark" parent="Theme.AppCompat"/>
 


### PR DESCRIPTION
**What does this implement/fix? Please describe.**
- Implements a new Theme called "system". The systemTheme is being controlled by the system and displays eighter a dark or light theme. This feature implements well with android's like LineageOS. Here is the system wide theme!!

**Does this close any currently open issues?**
-No

**Additional context**
- Future additions are applying the system accentColor to the app.
- Future code cleanup with "AppCompatDelegate.MODE_NIGHT_..." FOLLOW_SYSTEM / NO / YES" so the existing styles can be removed and controlled by forcing the themeMode thus only one style is needed.

**Where has this been tested?**
- Operating System: Lineage OS 15.1 (Android 8.1)
- Platform: -
- Target Platform: -
- Toolchain Version: -
- SDK Version: 27
