### PR TITLE
System Theme option reworked

### DIFF
--- a/app/build.properties
+++ b/app/build.properties
@@ -1,7 +1,7 @@
 #Build Properties
-#Tue Jun 12 16:57:46 CEST 2018
+#Fri Jun 15 12:08:41 CEST 2018
 version_minor=9
-version_build=2
+version_build=4
 version_patch=1
 version_major=1
 version_store=39

--- a/app/build.properties
+++ b/app/build.properties
@@ -1,7 +1,7 @@
 #Build Properties
-#Fri Jun 15 12:08:41 CEST 2018
+#Fri Jun 15 12:41:41 CEST 2018
 version_minor=9
-version_build=4
+version_build=6
 version_patch=1
 version_major=1
 version_store=39

--- a/app/build.properties
+++ b/app/build.properties
@@ -1,7 +1,7 @@
 #Build Properties
-#Mon Jun 11 19:50:17 EDT 2018
+#Tue Jun 12 16:57:46 CEST 2018
 version_minor=9
-version_build=1
+version_build=2
 version_patch=1
-version_store=39
 version_major=1
+version_store=39

--- a/app/src/main/java/com/vrem/wifianalyzer/settings/ThemeStyle.java
+++ b/app/src/main/java/com/vrem/wifianalyzer/settings/ThemeStyle.java
@@ -25,7 +25,8 @@ import com.vrem.wifianalyzer.R;
 
 public enum ThemeStyle {
     DARK(R.style.ThemeDark, R.style.ThemeDarkNoActionBar),
-    LIGHT(R.style.ThemeLight, R.style.ThemeLightNoActionBar);
+    LIGHT(R.style.ThemeLight, R.style.ThemeLightNoActionBar),
+    SYSTEM(R.style.ThemeSystem, R.style.ThemeSystemNoActionBar);
 
     private final int theme;
     private final int themeNoActionBar;

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -93,6 +93,8 @@
     <string name="theme_title">"Theme"</string>
     <string name="theme_dark">"Dunkel"</string>
     <string name="theme_light">"Hell"</string>
+    <string name="theme_system">"System"</string>
+
 
     <string name="wifi_off_on_exit_title">"WLAN beim Verlassen deaktivieren"</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -95,6 +95,7 @@
     <string name="theme_title">"Tema"</string>
     <string name="theme_dark">"Oscuro"</string>
     <string name="theme_light">"Claro"</string>
+    <string name="theme_system">"Sistema"</string>
 
     <string name="wifi_off_on_exit_title">"Apagar Wifi al salir"</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,6 +93,7 @@
     <string name="theme_title">"Thème"</string>
     <string name="theme_dark">"Foncé"</string>
     <string name="theme_light">"Clair"</string>
+    <string name="theme_system">"Système"</string>
 
     <string name="wifi_off_on_exit_title">"WiFi à la sortie"</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -92,6 +92,7 @@
     <string name="theme_title">"Tema"</string>
     <string name="theme_dark">"Scuro"</string>
     <string name="theme_light">"Chiaro"</string>
+    <string name="theme_system">"Sistema"</string>
 
     <string name="wifi_off_on_exit_title">"WiFi fuori all\'uscita"</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -95,6 +95,7 @@
     <string name="theme_title">"Motyw"</string>
     <string name="theme_dark">"Ciemny"</string>
     <string name="theme_light">"Jasny"</string>
+    <string name="theme_system">"System"</string>
 
     <string name="wifi_off_on_exit_title">"Wyłączanie WiFi przy wyjściu"</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -93,6 +93,7 @@
     <string name="theme_title">"Tema"</string>
     <string name="theme_dark">"Escuro"</string>
     <string name="theme_light">"Claro"</string>
+    <string name="theme_system">"Sistema"</string>
 
     <string name="wifi_off_on_exit_title">"Desativar Wi-Fi ao sair"</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -93,6 +93,7 @@
     <string name="theme_title">"Цветовая тема"</string>
     <string name="theme_dark">"Темная"</string>
     <string name="theme_light">"Светлая"</string>
+    <string name="theme_system">"System"</string>
 
     <string name="wifi_off_on_exit_title">"WiFi выключен при выходе"</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -93,6 +93,7 @@
     <string name="theme_title">"主题"</string>
     <string name="theme_dark">"深"</string>
     <string name="theme_light">"浅"</string>
+    <string name="theme_system">"System"</string>
 
     <string name="wifi_off_on_exit_title">"退出时关闭WiFi"</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -92,6 +92,7 @@
     <string name="theme_title">"主題"</string>
     <string name="theme_dark">"深"</string>
     <string name="theme_light">"淺"</string>
+    <string name="theme_system">"System"</string>
 
     <string name="wifi_off_on_exit_title">"退出時關閉WiFi"</string>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -97,11 +97,13 @@
     <string-array name="theme_index_array" translatable="false">
         <item>0</item>
         <item>1</item>
+        <item>2</item>
     </string-array>
 
     <string-array name="theme_array">
         <item>@string/theme_dark</item>
         <item>@string/theme_light</item>
+        <item>@string/theme_system</item>
     </string-array>
 
     <string-array name="graph_colors" translatable="false">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -41,4 +41,7 @@
     <color name="warning_color">#FFC107</color>
     <!-- green_500 -->
     <color name="success_color">#4CAF50</color>
+
+    <!-- dark gray -->
+    <color name="theme_color">#212121</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="theme_default" translatable="false">"0"</string>
     <string name="theme_dark">"Dark"</string>
     <string name="theme_light">"Light"</string>
+    <string name="theme_system">"System"</string>
 
     <string name="wifi_off_on_exit_title">"WiFi off on Exit"</string>
     <string name="wifi_off_on_exit_key" translatable="false">"wifi_off_on_exit"</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,6 +33,15 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="ThemeSystem" parent="Theme.AppCompat.DayNight">
+        <item name="colorPrimary">@color/theme_color</item>
+    </style>
+
+    <style name="ThemeSystemNoActionBar" parent="ThemeSystem">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
     <style name="ThemeOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">

--- a/app/src/test/java/com/vrem/wifianalyzer/settings/ThemeStyleTest.java
+++ b/app/src/test/java/com/vrem/wifianalyzer/settings/ThemeStyleTest.java
@@ -49,19 +49,21 @@ public class ThemeStyleTest {
 
     @Test
     public void testThemeStyle() {
-        assertEquals(2, ThemeStyle.values().length);
+        assertEquals(3, ThemeStyle.values().length);
     }
 
     @Test
     public void testGetTheme() {
         assertEquals(R.style.ThemeLight, ThemeStyle.LIGHT.getTheme());
         assertEquals(R.style.ThemeDark, ThemeStyle.DARK.getTheme());
+        assertEquals(R.style.ThemeSystem, ThemeStyle.SYSTEM.getTheme());
     }
 
     @Test
     public void testGetThemeNoActionBar() {
         assertEquals(R.style.ThemeLightNoActionBar, ThemeStyle.LIGHT.getThemeNoActionBar());
         assertEquals(R.style.ThemeDarkNoActionBar, ThemeStyle.DARK.getThemeNoActionBar());
+        assertEquals(R.style.ThemeSystemNoActionBar, ThemeStyle.SYSTEM.getThemeNoActionBar());
     }
 
     @Test


### PR DESCRIPTION
What does this implement/fix? Please describe.

I reworked my last commit other is the same:
  Implements a new Theme called "system". The systemTheme is being controlled by the system and displays either a dark or light theme. This feature implements well with android's like LineageOS. Here is the system wide theme!!

Does this close any currently open issues?
-No

Additional context

    Future additions are applying the system accentColor to the app.
    Future code cleanup with "AppCompatDelegate.MODE_NIGHT_..." FOLLOW_SYSTEM / NO / YES" so the existing styles can be removed and controlled by forcing the themeMode thus only one style is needed.

Where has this been tested?

    Operating System: Lineage OS 15.1 (Android 8.1), Android Preview SDK 28, Android 7.1.1, Android 8.0 (and of cause the emulator in this case android P again)
    Platform: -
    Target Platform: -
    Toolchain Version: -
    SDK Version: 27, 28, 25,26
