### PR TITLE
Add missing permission for Oneplus6 with Android 9.0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
**What does this implement/fix? Please describe.**
This PR fixes the failure to scan wifi networks on the Oneplus 6 with Android 9 (Pie).

**Does this close any currently open issues?**

This fix is an addition to issue #202.

**Additional context**
The ACCESS_FINE_LOCATION permission is required for the wifi scan to
work on the Oneplus6 with Android 9.0. Without this permission, the
following errors are triggered:

    E/libc: Access denied finding property "vendor.perf.iop_v3.enable"
    E/libc: Access denied finding property "vendor.perf.iop_v3.enable.debug"

Both other permissions are still required for the scan to work.

**Where has this been tested?**
- Operating System: OxygenOS 9.0 (Android 9.0)
- Platform: Oneplus 6 (Model number: `ONEPLUS A6007`)
- Target Platform: 22
- Toolchain Version: 28.0.2
- SDK Version: 27
