### PR TITLE
Added location permission.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Newer versions of android 6+ require additional location permission in order to scan the wifi.

Thanks for sending a pull request!

[How to submit a pull request](https://github.com/VREMSoftwareDevelopment/WiFiAnalyzer/wiki/Pull-Request)

**What does this implement/fix? Please describe.**
Works on Android p.

**Does this close any currently open issues?**
#215

**Additional context**
none

**Where has this been tested?**

