### PR TITLE
Added timestamp to exported Access_Point filename

### DIFF
--- a/app/src/main/java/com/vrem/wifianalyzer/navigation/items/ExportItem.java
+++ b/app/src/main/java/com/vrem/wifianalyzer/navigation/items/ExportItem.java
@@ -104,7 +104,11 @@ class ExportItem implements NavigationItem {
     @NonNull
     private String getTitle(@NonNull MainActivity mainActivity) {
         Resources resources = mainActivity.getResources();
-        return resources.getString(R.string.action_access_points);
+        // add timestamp to generated filename with no spaces
+        String TIME_STAMP_FORMAT = "yyyyMMdd_HHmmss";
+        String timeStamp = new SimpleDateFormat(TIME_STAMP_FORMAT).format(new Date());
+        String stampedFilename = timeStamp +"-"+ resources.getString(R.string.action_access_points);
+        return stampedFilename;
     }
 
     private Intent createIntent(String title, String data) {


### PR DESCRIPTION
**What does this implement/fix? Please describe.**
- It implements current date & time stamp to generated Access_Point file name.

**Does this close any currently open issues?**
- No

**Where has this been tested?**
- Operating System: Android
- Platform: Android 9 (API level 28)
- Target Platform: Android 9.0 (Qualcomm MSM8953 Snapdragon 625)
- Toolchain Version: android-ndk-r19c
- SDK Version: 28
