### PR TITLE
Add 169 and 173 channel for ETSI region

### DIFF
--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelCountryGHZ5.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelCountryGHZ5.kt
@@ -25,7 +25,10 @@ internal class WiFiChannelCountryGHZ5 {
     private val channelsSet3: SortedSet<Int> = sortedSetOf(149, 153, 157, 161, 165)
     private val channelsToExcludeCanada: SortedSet<Int> = sortedSetOf(120, 124, 128)
     private val channelsToExcludeIsrael: SortedSet<Int> = channelsSet2.union(channelsSet3).toSortedSet()
+    private val channelsToExcludeETSI: SortedSet<Int> = sortedSetOf(144)
+    private val channelsToIncludeETSI: SortedSet<Int> = sortedSetOf(169, 173)
     private val channels: SortedSet<Int> = channelsSet1.union(channelsSet2).union(channelsSet3).toSortedSet()
+
     private val channelsToExclude: Map<String, SortedSet<Int>> = mapOf(
             "AU" to channelsToExcludeCanada,    // Australia
             "CA" to channelsToExcludeCanada,    // Canada
@@ -34,11 +37,73 @@ internal class WiFiChannelCountryGHZ5 {
             "JP" to channelsSet3,               // Japan
             "KR" to channelsSet2,               // South Korea
             "TR" to channelsSet3,               // Turkey
-            "ZA" to channelsSet3                // South Africa
+            "ZA" to channelsSet3,               // South Africa
+            "AT" to channelsToExcludeETSI,      // ETSI Austria
+            "BE" to channelsToExcludeETSI,      // ETSI Belgium
+            "CH" to channelsToExcludeETSI,      // ETSI Switzerland
+            "CY" to channelsToExcludeETSI,      // ETSI Cyprus
+            "CZ" to channelsToExcludeETSI,      // ETSI Czechia
+            "DE" to channelsToExcludeETSI,      // ETSI Germany
+            "DK" to channelsToExcludeETSI,      // ETSI Denmark
+            "EE" to channelsToExcludeETSI,      // ETSI Estonia
+            "ES" to channelsToExcludeETSI,      // ETSI Spain
+            "FI" to channelsToExcludeETSI,      // ETSI Finland
+            "FR" to channelsToExcludeETSI,      // ETSI France
+            "GR" to channelsToExcludeETSI,      // ETSI Greece
+            "HU" to channelsToExcludeETSI,      // ETSI Hungary
+            "IE" to channelsToExcludeETSI,      // ETSI Ireland
+            "IS" to channelsToExcludeETSI,      // ETSI Iceland
+            "IT" to channelsToExcludeETSI,      // ETSI Italy
+            "LI" to channelsToExcludeETSI,      // ETSI Liechtenstein
+            "LT" to channelsToExcludeETSI,      // ETSI Lithuania
+            "LU" to channelsToExcludeETSI,      // ETSI Luxembourg
+            "LV" to channelsToExcludeETSI,      // ETSI Latvia
+            "MT" to channelsToExcludeETSI,      // ETSI Malta
+            "NL" to channelsToExcludeETSI,      // ETSI Netherlands
+            "NO" to channelsToExcludeETSI,      // ETSI Norway
+            "PL" to channelsToExcludeETSI,      // ETSI Poland
+            "PT" to channelsToExcludeETSI,      // ETSI Portugal
+            "RO" to channelsToExcludeETSI,      // ETSI Romania
+            "SE" to channelsToExcludeETSI,      // ETSI Sweden
+            "SI" to channelsToExcludeETSI,      // ETSI Slovenia
+            "SK" to channelsToExcludeETSI       // ETSI Slovakia
+    )
+
+    private val channelsToInclude: Map<String, SortedSet<Int>> = mapOf(
+            "AT" to channelsToIncludeETSI,      // ETSI Austria
+            "BE" to channelsToIncludeETSI,      // ETSI Belgium
+            "CH" to channelsToIncludeETSI,      // ETSI Switzerland
+            "CY" to channelsToIncludeETSI,      // ETSI Cyprus
+            "CZ" to channelsToIncludeETSI,      // ETSI Czechia
+            "DE" to channelsToIncludeETSI,      // ETSI Germany
+            "DK" to channelsToIncludeETSI,      // ETSI Denmark
+            "EE" to channelsToIncludeETSI,      // ETSI Estonia
+            "ES" to channelsToIncludeETSI,      // ETSI Spain
+            "FI" to channelsToIncludeETSI,      // ETSI Finland
+            "FR" to channelsToIncludeETSI,      // ETSI France
+            "GR" to channelsToIncludeETSI,      // ETSI Greece
+            "HU" to channelsToIncludeETSI,      // ETSI Hungary
+            "IE" to channelsToIncludeETSI,      // ETSI Ireland
+            "IS" to channelsToIncludeETSI,      // ETSI Iceland
+            "IT" to channelsToIncludeETSI,      // ETSI Italy
+            "LI" to channelsToIncludeETSI,      // ETSI Liechtenstein
+            "LT" to channelsToIncludeETSI,      // ETSI Lithuania
+            "LU" to channelsToIncludeETSI,      // ETSI Luxembourg
+            "LV" to channelsToIncludeETSI,      // ETSI Latvia
+            "MT" to channelsToIncludeETSI,      // ETSI Malta
+            "NL" to channelsToIncludeETSI,      // ETSI Netherlands
+            "NO" to channelsToIncludeETSI,      // ETSI Norway
+            "PL" to channelsToIncludeETSI,      // ETSI Poland
+            "PT" to channelsToIncludeETSI,      // ETSI Portugal
+            "RO" to channelsToIncludeETSI,      // ETSI Romania
+            "SE" to channelsToIncludeETSI,      // ETSI Sweden
+            "SI" to channelsToIncludeETSI,      // ETSI Slovenia
+            "SK" to channelsToIncludeETSI       // ETSI Slovakia
     )
 
     fun findChannels(countryCode: String): SortedSet<Int> =
             channels.subtract(channelsToExclude[countryCode.capitalize()]?.toSortedSet()
+                    ?: setOf()).union(channelsToInclude[countryCode.capitalize()]?.toSortedSet()
                     ?: setOf())
                     .toSortedSet()
 

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ5.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ5.kt
@@ -39,7 +39,7 @@ class WiFiChannelsGHZ5 : WiFiChannels(RANGE, SETS) {
     companion object {
         val SET1 = WiFiChannelPair(WiFiChannel(36, 5180), WiFiChannel(64, 5320))
         val SET2 = WiFiChannelPair(WiFiChannel(100, 5500), WiFiChannel(144, 5720))
-        val SET3 = WiFiChannelPair(WiFiChannel(149, 5745), WiFiChannel(165, 5825))
+        val SET3 = WiFiChannelPair(WiFiChannel(149, 5745), WiFiChannel(173, 5865))
         val SETS = listOf(SET1, SET2, SET3)
         private val RANGE = WiFiRange(4900, 5899)
     }


### PR DESCRIPTION
**What does this implement/fix? Please describe.**
Allow 169 and 173 channel for ETSI region. It also disable 144

**Does this close any currently open issues?**
[316](https://github.com/VREMSoftwareDevelopment/WiFiAnalyzer/issues/316)

**Additional context**
Fixed channel list for France (in ETSI region)
![Screenshot_20201109-021451](https://user-images.githubusercontent.com/40322493/98490585-32261d80-2232-11eb-86aa-485eb73e1588.png)
169 and 173 channel 
![Screenshot_20201109-021620](https://user-images.githubusercontent.com/40322493/98490657-6a2d6080-2232-11eb-86c5-eaefa6a97690.png)
Disable 144 channel
![Screenshot_20201109-021431](https://user-images.githubusercontent.com/40322493/98490593-381bfe80-2232-11eb-884a-24f058dc2bcb.png)

**Where has this been tested?**
- Operating System: Android 11
- Platform: Google Pixel 3a XL
- Target Platform: 30
- Toolchain Version: 30.0.2
- SDK Version: 30
