### PR TITLE
Utilize some KTX and fix a deprecation

### DIFF
--- a/app/src/main/kotlin/com/vrem/util/StringUtils.kt
+++ b/app/src/main/kotlin/com/vrem/util/StringUtils.kt
@@ -17,11 +17,6 @@
  */
 package com.vrem.util
 
-import android.annotation.TargetApi
-import android.os.Build
-import android.text.Html
-import android.text.Spanned
-
 val String.Companion.EMPTY: String get() = ""
 val String.Companion.SPACE_SEPARATOR: String get() = " "
 
@@ -30,13 +25,3 @@ fun String.specialTrim(): String = this.trim { it <= ' ' }.replace(" +".toRegex(
 fun String.toHtml(color: Int, small: Boolean): String =
         "<font color='" + color + "'><" + (if (small) "small" else "strong") +
                 ">" + this + "</" + (if (small) "small" else "strong") + "></font>"
-
-fun String.fromHtml(): Spanned =
-        if (buildMinVersionN()) fromHtmlAndroidN() else fromHtmlLegacy()
-
-@TargetApi(Build.VERSION_CODES.N)
-private fun String.fromHtmlAndroidN(): Spanned = Html.fromHtml(this, Html.FROM_HTML_MODE_LEGACY)
-
-@Suppress("DEPRECATION")
-private fun String.fromHtmlLegacy(): Spanned = Html.fromHtml(this)
-

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/about/AboutFragment.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/about/AboutFragment.kt
@@ -31,10 +31,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.content.pm.PackageInfoCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.vrem.util.EMPTY
-import com.vrem.util.buildMinVersionP
 import com.vrem.util.readFile
 import com.vrem.wifianalyzer.MainContext
 import com.vrem.wifianalyzer.R
@@ -104,17 +104,9 @@ class AboutFragment : Fragment() {
     private fun applicationVersion(activity: FragmentActivity): String =
             try {
                 val packageInfo: PackageInfo = activity.packageManager.getPackageInfo(activity.packageName, 0)
-                packageInfo.versionName + " - " + versionCode(packageInfo)
+                packageInfo.versionName + " - " + PackageInfoCompat.getLongVersionCode(packageInfo)
             } catch (e: NameNotFoundException) {
                 String.EMPTY
-            }
-
-    private fun versionCode(packageInfo: PackageInfo): String =
-            if (buildMinVersionP()) {
-                packageInfo.longVersionCode.toString()
-            } else {
-                @Suppress("DEPRECATION")
-                packageInfo.versionCode.toString()
             }
 
     private class WriteReviewClickListener(private val activity: Activity) : View.OnClickListener {

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/navigation/availability/WiFiSwitch.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/navigation/availability/WiFiSwitch.kt
@@ -17,9 +17,9 @@
  */
 package com.vrem.wifianalyzer.navigation.availability
 
+import androidx.core.text.parseAsHtml
 import com.vrem.util.EMPTY
 import com.vrem.util.compatColor
-import com.vrem.util.fromHtml
 import com.vrem.util.toHtml
 import com.vrem.wifianalyzer.MainActivity
 import com.vrem.wifianalyzer.MainContext
@@ -54,7 +54,7 @@ private fun actionBarOn(mainActivity: MainActivity) {
         val wiFiBand5 = resources.getString(WiFiBand.GHZ5.textResource)
         val wiFiBand = MainContext.INSTANCE.settings.wiFiBand()
         val subtitle = makeSubtitle(WiFiBand.GHZ2 == wiFiBand, wiFiBand2, wiFiBand5, colorSelected, colorNotSelected)
-        it.subtitle = subtitle.fromHtml()
+        it.subtitle = subtitle.parseAsHtml()
     }
 }
 

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/navigation/items/FragmentItem.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/navigation/items/FragmentItem.kt
@@ -21,7 +21,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentTransaction
+import androidx.fragment.app.commit
 import com.vrem.wifianalyzer.MainActivity
 import com.vrem.wifianalyzer.R
 import com.vrem.wifianalyzer.navigation.NavigationMenu
@@ -36,8 +36,9 @@ internal class FragmentItem(val fragment: Fragment, override val registered: Boo
     }
 
     private fun startFragment(fragmentManager: FragmentManager) {
-        val fragmentTransaction: FragmentTransaction = fragmentManager.beginTransaction()
-        fragmentTransaction.replace(R.id.main_fragment, fragment).commit()
+        fragmentManager.commit {
+            replace(R.id.main_fragment, fragment)
+        }
     }
 
     private fun updateMainActivity(mainActivity: MainActivity, menuItem: MenuItem, navigationMenu: NavigationMenu) {

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigation.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigation.kt
@@ -20,9 +20,9 @@ package com.vrem.wifianalyzer.wifi.channelgraph
 import android.content.Context
 import android.view.View
 import android.widget.Button
+import androidx.core.text.parseAsHtml
 import com.vrem.annotation.OpenClass
 import com.vrem.util.compatColor
-import com.vrem.util.fromHtml
 import com.vrem.wifianalyzer.MainContext
 import com.vrem.wifianalyzer.R
 import com.vrem.wifianalyzer.wifi.band.WiFiChannelPair
@@ -50,7 +50,7 @@ class ChannelGraphNavigation(private val view: View, private val mainContext: Co
         navigationSet.entries.forEach { entry ->
             with(view.findViewById<Button>(entry.value)) {
                 setOnClickListener { onClickListener(entry.key) }
-                text = """<strong>${entry.key.first.channel} &#8722 ${entry.key.second.channel}</strong>""".fromHtml()
+                text = """<strong>${entry.key.first.channel} &#8722 ${entry.key.second.channel}</strong>""".parseAsHtml()
             }
         }
     }

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelrating/ChannelRatingAdapter.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelrating/ChannelRatingAdapter.kt
@@ -20,6 +20,7 @@ package com.vrem.wifianalyzer.wifi.channelrating
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.view.View
@@ -99,17 +100,20 @@ class ChannelRatingAdapter(
                 setRatingBarColorLegacy(ratingBar.progressDrawable, color)
             }
 
-    @Suppress("DEPRECATION")
     private fun setRatingBarColorLegacy(drawable: Drawable, color: Int) {
         try {
             val background = context.compatColor(R.color.background)
             val layerDrawable = drawable as LayerDrawable
-            layerDrawable.getDrawable(0).setColorFilter(background, PorterDuff.Mode.SRC_ATOP)
-            layerDrawable.getDrawable(1).setColorFilter(background, PorterDuff.Mode.SRC_ATOP)
-            layerDrawable.getDrawable(2).setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+            layerDrawable.getDrawable(0).colorFilter(background)
+            layerDrawable.getDrawable(1).colorFilter(background)
+            layerDrawable.getDrawable(2).colorFilter(color)
         } catch (e: Exception) {
-            drawable.setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+            drawable.colorFilter(color)
         }
+    }
+
+    private fun Drawable.colorFilter(i: Int) {
+        this.colorFilter = PorterDuffColorFilter(i, PorterDuff.Mode.SRC_ATOP)
     }
 
     internal fun bestChannels(wiFiBand: WiFiBand, wiFiChannels: List<WiFiChannel>): Message {

--- a/app/src/test/kotlin/com/vrem/util/StringUtilsTest.kt
+++ b/app/src/test/kotlin/com/vrem/util/StringUtilsTest.kt
@@ -19,6 +19,7 @@ package com.vrem.util
 
 import android.os.Build
 import android.text.Spanned
+import androidx.core.text.parseAsHtml
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -70,7 +71,7 @@ class StringUtilsTest {
         val expected = "ThisIsText"
         val text = "<font color='20'><small>$expected</small></font>"
         // execute
-        val actual: Spanned = text.fromHtml()
+        val actual: Spanned = text.parseAsHtml()
         // verify
         assertEquals(expected, actual.toString())
     }
@@ -82,7 +83,7 @@ class StringUtilsTest {
         val expected = "ThisIsText"
         val text = "<font color='20'><small>$expected</small></font>"
         // execute
-        val actual: Spanned = text.fromHtml()
+        val actual: Spanned = text.parseAsHtml()
         // verify
         assertEquals(expected, actual.toString())
     }

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/navigation/availability/WiFiSwitchOnTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/navigation/availability/WiFiSwitchOnTest.kt
@@ -21,9 +21,9 @@ import android.os.Build
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.ActionBar
+import androidx.core.text.parseAsHtml
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.*
-import com.vrem.util.fromHtml
 import com.vrem.wifianalyzer.MainActivity
 import com.vrem.wifianalyzer.MainContext
 import com.vrem.wifianalyzer.R
@@ -153,7 +153,7 @@ class WiFiSwitchOnTest {
         val colorSelected = mainActivity.getColor(R.color.selected)
         val colorNotSelected = mainActivity.getColor(R.color.regular)
         val subtitle = makeSubtitle(WiFiBand.GHZ2 == wiFiBand, wiFiBand2, wiFiBand5, colorSelected, colorNotSelected)
-        return subtitle.fromHtml()
+        return subtitle.parseAsHtml()
     }
 
 }


### PR DESCRIPTION
**What does this implement/fix? Please describe.**
- The first two commits replace some things. These do the jobs of the removed functions internally.
- The third commit fixes a deprecation
- The fourth commit utilizes a [Fragment KTX extension](https://developer.android.com/kotlin/ktx/extensions-list#for_fragmentmanager)

**Does this close any currently open issues?**
No.

**Additional context**
- [parseAsHtml](https://developer.android.com/kotlin/ktx/extensions-list#for_kotlinstring_3) calls [HtmlCompat.fromHtml](https://developer.android.com/reference/androidx/core/text/HtmlCompat#fromHtml(java.lang.String,%20int,%20android.text.Html.ImageGetter,%20android.text.Html.TagHandler)) internally
- [PackageInfoCompat.getLongVersionCode](https://developer.android.com/reference/androidx/core/content/pm/PackageInfoCompat#getLongVersionCode(android.content.pm.PackageInfo)) does the API check internally

**Where has this been tested?**
No testing required... but I tested on my phone anyway. Everything works fine.
