### PR TITLE
make it more clear that SSID filter is case sensitive

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -123,6 +123,7 @@
     <string name="filter_close">"Затвори"</string>
     <string name="filter_reset">"Нулирай"</string>
     <string name="filter_apply">"Приложи"</string>
+    <string name="filter_ssid_title">"SSID (различаващ главни от малки букви)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi диапазон"</string>
     <string name="filter_strength_title">"Сила на сигнала"</string>
     <string name="filter_security_title">"Защита"</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Schließen"</string>
     <string name="filter_reset">"Zurücksetzen"</string>
     <string name="filter_apply">"Anwenden"</string>
+    <string name="filter_ssid_title">"SSID (case-sensitiv)"</string>
     <string name="filter_wifi_band_title">"WLAN-Frequenzbänder"</string>
     <string name="filter_strength_title">"Signalstärke"</string>
     <string name="filter_security_title">"Sicherheit"</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Κλείσιμο"</string>
     <string name="filter_reset">"Επαναφορά"</string>
     <string name="filter_apply">"Εφαρμογή"</string>
+    <string name="filter_ssid_title">"SSID (διάκριση πεζών-κεφαλαίων)"</string>
     <string name="filter_wifi_band_title">"Ζώνη Wi-Fi"</string>
     <string name="filter_strength_title">"Ισχύς σήματος"</string>
     <string name="filter_security_title">"Ασφάλεια"</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Cerrar"</string>
     <string name="filter_reset">"Reset"</string>
     <string name="filter_apply">"Aplicar"</string>
+    <string name="filter_ssid_title">"SSID (sensible a mayúsculas)"</string>
     <string name="filter_wifi_band_title">"Banda de Wi-Fi"</string>
     <string name="filter_strength_title">"Intensidad de señal"</string>
     <string name="filter_security_title">"Seguridad"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Fermer"</string>
     <string name="filter_reset">"Réinitialiser"</string>
     <string name="filter_apply">"Appliquer"</string>
+    <string name="filter_ssid_title">"SSID (sensible à la casse)"</string>
     <string name="filter_wifi_band_title">"Fréquence Wi-Fi"</string>
     <string name="filter_strength_title">"Intensité du signal"</string>
     <string name="filter_security_title">"Sécurité"</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Chiudi"</string>
     <string name="filter_reset">"Resetta"</string>
     <string name="filter_apply">"Applica"</string>
+    <string name="filter_ssid_title">"SSID (sensibile alle maiuscole)"</string>
     <string name="filter_wifi_band_title">"Banda Wi-Fi"</string>
     <string name="filter_strength_title">"Potenza Segnale"</string>
     <string name="filter_security_title">"Sicurezza"</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -118,6 +118,7 @@
     <string name="filter_close">"閉じる"</string>
     <string name="filter_reset">"リセット"</string>
     <string name="filter_apply">"適用"</string>
+    <string name="filter_ssid_title">"SSID (ケース・センシティブ)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi バンド"</string>
     <string name="filter_strength_title">"信号の強さ"</string>
     <string name="filter_security_title">"セキュリティ"</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -118,6 +118,7 @@
     <string name="filter_close">"Sluiten"</string>
     <string name="filter_reset">"Reset"</string>
     <string name="filter_apply">"Toepassen"</string>
+    <string name="filter_ssid_title">"SSID (hoofdlettergevoelig)"</string>
     <string name="filter_wifi_band_title">"Wifi-band"</string>
     <string name="filter_strength_title">"Signaalsterkte"</string>
     <string name="filter_security_title">"Beveiliging"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Zamknij"</string>
     <string name="filter_reset">"Resetuj"</string>
     <string name="filter_apply">"Zastosuj"</string>
+    <string name="filter_ssid_title">"SSID (sprawa ma znaczenie)"</string>
     <string name="filter_wifi_band_title">"Pasmo Wi-Fi"</string>
     <string name="filter_strength_title">"Siła sygnału"</string>
     <string name="filter_security_title">"Bezpieczeństwo"</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Fechar"</string>
     <string name="filter_reset">"Redefinir"</string>
     <string name="filter_apply">"Aplicar"</string>
+    <string name="filter_ssid_title">"SSID (sensível à caixa das letras)"</string>
     <string name="filter_wifi_band_title">"Frequência do Wi-Fi"</string>
     <string name="filter_strength_title">"Intensidade do Sinal"</string>
     <string name="filter_security_title">"Protocolo de Segurança"</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"Закрыть"</string>
     <string name="filter_reset">"Сброс"</string>
     <string name="filter_apply">"Применить"</string>
+    <string name="filter_ssid_title">"SSID (Чувствительность к регистру символов)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi диапазон"</string>
     <string name="filter_strength_title">"Уровень сигнала"</string>
     <string name="filter_security_title">"Безопасность"</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -123,6 +123,7 @@
     <string name="filter_close">"Kapat"</string>
     <string name="filter_reset">"Sıfırla"</string>
     <string name="filter_apply">"Uygula"</string>
+    <string name="filter_ssid_title">"SSID (harfe duyarlı)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi Bandı"</string>
     <string name="filter_strength_title">"Sinyal Gücü"</string>
     <string name="filter_security_title">"Güvenlik"</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -118,6 +118,7 @@
     <string name="filter_close">"Закрити"</string>
     <string name="filter_reset">"Скидання"</string>
     <string name="filter_apply">"Застосувати"</string>
+    <string name="filter_ssid_title">"SSID (чутливий до регістру)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi діапазон"</string>
     <string name="filter_strength_title">"Рівень сигналу"</string>
     <string name="filter_security_title">"Безпека"</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -119,6 +119,7 @@
     <string name="filter_close">"关闭"</string>
     <string name="filter_reset">"重置"</string>
     <string name="filter_apply">"应用"</string>
+    <string name="filter_ssid_title">"SSID (區分大小寫)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi 频段"</string>
     <string name="filter_strength_title">"信号强度"</string>
     <string name="filter_security_title">"安全性"</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -121,6 +121,7 @@
     <string name="filter_close">"關閉"</string>
     <string name="filter_reset">"重設"</string>
     <string name="filter_apply">"套用"</string>
+    <string name="filter_ssid_title">"SSID (區分大小寫)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi 頻段"</string>
     <string name="filter_strength_title">"訊號強度"</string>
     <string name="filter_security_title">"安全"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,7 +240,7 @@
     <string name="filter_close">"Close"</string>
     <string name="filter_reset">"Reset"</string>
     <string name="filter_apply">"Apply"</string>
-    <string name="filter_ssid_title" translatable="false">"SSID"</string>
+    <string name="filter_ssid_title" translatable="false">"SSID (case sensitive)"</string>
     <string name="filter_ssid_key" translatable="false">"filter_ssid"</string>
     <string name="filter_ssid_hint" translatable="false">"ssid SSID"</string>
     <string name="filter_wifi_band_title">"Wi-Fi Band"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,7 +240,7 @@
     <string name="filter_close">"Close"</string>
     <string name="filter_reset">"Reset"</string>
     <string name="filter_apply">"Apply"</string>
-    <string name="filter_ssid_title" translatable="false">"SSID (case sensitive)"</string>
+    <string name="filter_ssid_title" translatable="true">"SSID (case sensitive)"</string>
     <string name="filter_ssid_key" translatable="false">"filter_ssid"</string>
     <string name="filter_ssid_hint" translatable="false">"ssid SSID"</string>
     <string name="filter_wifi_band_title">"Wi-Fi Band"</string>


### PR DESCRIPTION
**What does this implement/fix? Please describe.**
- adds "(case sensitive)" to the SSID filter title

**Does this close any currently open issues?**
fixes #441

**Additional context**
- I guess this string might need translation now (currently it is marked as untranslatable), if so, please explain how your translation workflow works. 

**Where has this been tested?**
- Tested in emulator