### PR TITLE
Add monochrome icon

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ WiFiAnalyzer
+  ~ Copyright (C) 2015 - 2023 VREM Software Development <VREMSoftwareDevelopment@gmail.com>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="108dp"
+        android:height="108dp"
+        android:viewportWidth="240"
+        android:viewportHeight="240">
+    <group
+        android:translateX="24"
+        android:translateY="24">
+        <path
+            android:fillColor="#000000"
+            android:pathData="M148.93,73.56l-9.68,12.75c-8.16,-6.189 -17.68,-10.67 -28.029,-12.92c-4.921,-1.06 -10.021,-1.62 -15.229,-1.62c-5.221,0 -10.32,0.561 -15.23,1.62c-10.34,2.25 -19.85,6.73 -28,12.91h-0.01l-9.68,-12.76c0.06,-0.05 0.13,-0.11 0.199,-0.15C57.94,62.34 76.19,55.8 95.99,55.8c19.779,0 38.039,6.54 52.71,17.59C148.779,73.43 148.859,73.5 148.93,73.56z"/>
+        <path
+            android:fillColor="#000000"
+            android:pathData="M110.996,123.52l-14.953,19.709L96,143.271l-15.01,-19.767c4.163,-3.155 9.354,-5.032 14.998,-5.032C101.627,118.479 106.834,120.35 110.996,123.52z"/>
+        <path
+            android:fillColor="#000000"
+            android:pathData="M130.141,98.313l-10.05,13.244c-6.694,-5.098 -15.051,-8.119 -24.102,-8.119c-9.042,0 -17.38,3.021 -24.078,8.104L61.86,98.286c9.489,-7.205 21.323,-11.482 34.129,-11.482C108.809,86.804 120.652,91.081 130.141,98.313z"/>
+    </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -20,4 +20,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -20,4 +20,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
The icon is same as foreground file with stroke colors set to black. The following screenshot shows how the monochrome icon looks in Android 13 (LineageOS 20).

![image](https://github.com/VREMSoftwareDevelopment/WiFiAnalyzer/assets/31443074/38b69ae9-599f-467f-8ef8-348e2063e7f6)
