### PR TITLE
Support fast roaming protocol (802.11 k/v/r) 

### DIFF
--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetail.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetail.kt
@@ -66,6 +66,7 @@ class AccessPointDetail {
         setViewWiFiBand(view, wiFiDetail.wiFiSignal)
         setView80211mc(view, wiFiDetail.wiFiSignal)
         setViewWiFiStandard(view, wiFiDetail.wiFiSignal)
+        setViewFastRoaming(view, wiFiDetail.wiFiSignal)
         setTimestamp(view, wiFiDetail.wiFiSignal)
         enableTextSelection(view)
         return view
@@ -168,6 +169,18 @@ class AccessPointDetail {
     private fun setViewWiFiBand(view: View, wiFiSignal: WiFiSignal) =
         view.findViewById<TextView>(R.id.wiFiBand)?.setText(wiFiSignal.wiFiBand.textResource)
 
+
+    private fun setViewFastRoaming(view: View, wiFiSignal: WiFiSignal) {
+        view.findViewById<TextView>(R.id.fastRoaming)?.let {
+            if (wiFiSignal.fastRoaming.isEmpty()) {
+                it.setText(R.string.unsupported_802_11_k_v_r)
+            } else {
+                it.text = wiFiSignal.fastRoaming.joinToString("") {
+                    fastRoaming -> "[${fastRoaming.protocol}]"
+                }
+            }
+        }
+    }
     private fun setViewWiFiStandard(view: View, wiFiSignal: WiFiSignal) =
         view.findViewById<TextView>(R.id.wiFiStandard)
             ?.setText(wiFiSignal.wiFiStandard.textResource)

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetail.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetail.kt
@@ -27,6 +27,7 @@ import com.vrem.annotation.OpenClass
 import com.vrem.util.EMPTY
 import com.vrem.wifianalyzer.MainContext
 import com.vrem.wifianalyzer.R
+import com.vrem.wifianalyzer.wifi.model.FastRoaming
 import com.vrem.wifianalyzer.wifi.model.WiFiAdditional
 import com.vrem.wifianalyzer.wifi.model.WiFiDetail
 import com.vrem.wifianalyzer.wifi.model.WiFiSecurity
@@ -174,9 +175,11 @@ class AccessPointDetail {
         view.findViewById<TextView>(R.id.fastRoaming)?.let {
             if (wiFiSignal.fastRoaming.isEmpty()) {
                 it.setText(R.string.unsupported_802_11_k_v_r)
+            } else if (wiFiSignal.fastRoaming.contains(FastRoaming.REQUIRE_ANDROID_R)) {
+                it.setText(R.string.require_android_11_802_11_k_v_r)
             } else {
-                it.text = wiFiSignal.fastRoaming.joinToString("") {
-                    fastRoaming -> "[${fastRoaming.protocol}]"
+                it.text = wiFiSignal.fastRoaming.joinToString("") { fastRoaming ->
+                    "[${fastRoaming.protocol}]"
                 }
             }
         }

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoaming.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoaming.kt
@@ -22,15 +22,16 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import java.nio.ByteBuffer
 
-enum class FastRoaming(val protocol: String) {
-    REQUIRE_ANDROID_R(""),
+enum class FastRoaming(val protocol: String = "") {
+    ILLEGAL_ATTR,
+    REQUIRE_ANDROID_R,
     K("802.11k"),
     V("802.11v"),
     R("802.11r");
 
     companion object {
         @RequiresApi(Build.VERSION_CODES.R)
-        fun transformOrNull(it: ScanResult.InformationElement): FastRoaming? =
+        fun transform(it: ScanResult.InformationElement): FastRoaming =
             if (it.id == WiFiSignal.RM_ENABLED_CAPABILITIES_IE &&
                 validRoamingBit(
                     it.bytes,
@@ -47,7 +48,7 @@ enum class FastRoaming(val protocol: String) {
             ) V
             else if (it.id == WiFiSignal.MOBILE_DOMAIN_IE
             ) R
-            else null
+            else ILLEGAL_ATTR
 
         // some evil access point broadcasts illegal package, which may trigger oob exception
         // make sure limit > index first

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoaming.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoaming.kt
@@ -1,0 +1,57 @@
+/*
+ * WiFiAnalyzer
+ * Copyright (C) 2015 - 2024 VREM Software Development <VREMSoftwareDevelopment@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+package com.vrem.wifianalyzer.wifi.model
+
+import android.net.wifi.ScanResult
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.nio.ByteBuffer
+
+enum class FastRoaming(val protocol: String) {
+    REQUIRE_ANDROID_R(""),
+    K("802.11k"),
+    V("802.11v"),
+    R("802.11r");
+
+    companion object {
+        @RequiresApi(Build.VERSION_CODES.R)
+        fun transformOrNull(it: ScanResult.InformationElement): FastRoaming? =
+            if (it.id == WiFiSignal.RM_ENABLED_CAPABILITIES_IE &&
+                validRoamingBit(
+                    it.bytes,
+                    WiFiSignal.NEIGHBOR_REPORT_IDX,
+                    WiFiSignal.NEIGHBOR_REPORT_BIT
+                )
+            ) K
+            else if (it.id == WiFiSignal.EXTENDED_CAPABILITIES_IE &&
+                validRoamingBit(
+                    it.bytes,
+                    WiFiSignal.BSS_TRANSITION_IDX,
+                    WiFiSignal.BSS_TRANSITION_BIT
+                )
+            ) V
+            else if (it.id == WiFiSignal.MOBILE_DOMAIN_IE
+            ) R
+            else null
+
+        // some evil access point broadcasts illegal package, which may trigger oob exception
+        // make sure limit > index first
+        private fun validRoamingBit(data: ByteBuffer, idx: Int, bit: Int) =
+            data.limit() > idx && data[idx].toInt().and(1 shl bit) == (1 shl bit)
+    }
+}

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiSignal.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiSignal.kt
@@ -27,7 +27,8 @@ data class WiFiSignal(
     val level: Int = 0,
     val is80211mc: Boolean = false,
     val wiFiStandard: WiFiStandard = WiFiStandard.UNKNOWN,
-    val timestamp: Long = 0
+    val timestamp: Long = 0,
+    val fastRoaming: List<FastRoaming> = listOf()
 ) {
 
     val wiFiBand: WiFiBand = WiFiBand.find(primaryFrequency)
@@ -73,7 +74,23 @@ data class WiFiSignal(
     companion object {
         const val FREQUENCY_UNITS = "MHz"
 
+        const val RM_ENABLED_CAPABILITIES_IE = 70
+        const val NEIGHBOR_REPORT_IDX = 0
+        const val NEIGHBOR_REPORT_BIT = 1
+
+        const val EXTENDED_CAPABILITIES_IE = 127
+        const val BSS_TRANSITION_IDX = 2
+        const val BSS_TRANSITION_BIT = 3
+
+        const val MOBILE_DOMAIN_IE = 54
         val EMPTY = WiFiSignal()
     }
 
 }
+
+enum class FastRoaming(val protocol :String) {
+    K("802.11k"),
+    V("802.11v"),
+    R("802.11r"),
+}
+

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiSignal.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiSignal.kt
@@ -89,6 +89,7 @@ data class WiFiSignal(
 }
 
 enum class FastRoaming(val protocol :String) {
+    REQUIRE_ANDROID_R(""),
     K("802.11k"),
     V("802.11v"),
     R("802.11r"),

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiSignal.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiSignal.kt
@@ -87,11 +87,3 @@ data class WiFiSignal(
     }
 
 }
-
-enum class FastRoaming(val protocol :String) {
-    REQUIRE_ANDROID_R(""),
-    K("802.11k"),
-    V("802.11v"),
-    R("802.11r"),
-}
-

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
@@ -65,7 +65,9 @@ internal class Transformer(private val cache: Cache) {
 
     internal fun fastRoaming(scanResult: ScanResult): List<FastRoaming> =
         if (minVersionR()) {
-            scanResult.informationElements.mapNotNull { FastRoaming.transformOrNull(it) }.sorted()
+            scanResult.informationElements.map { FastRoaming.transform(it) }
+                .filter { it != FastRoaming.ILLEGAL_ATTR }
+                .sorted()
         } else {
             listOf(FastRoaming.REQUIRE_ANDROID_R)
         }

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
@@ -99,7 +99,7 @@ internal class Transformer(private val cache: Cache) {
                 }
             }.sorted()
         } else {
-            listOf()
+            listOf(FastRoaming.REQUIRE_ANDROID_R)
         }
 
     internal fun minVersionR(): Boolean = buildMinVersionR()

--- a/app/src/main/res/layout/access_point_view_popup.xml
+++ b/app/src/main/res/layout/access_point_view_popup.xml
@@ -74,6 +74,14 @@
         tools:text="[WPA][WPA2][WPS][WPA3]" />
 
     <TextView
+        android:id="@+id/fastRoaming"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/security"
+        android:textStyle="italic"
+        tools:text="[802.11k][802.11v][802.11r]" />
+
+    <TextView
         android:id="@+id/vendorLong"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -132,4 +132,9 @@
     <string name="wifi_throttling_on">Регулирането на Wi-Fi сканирането е активирано</string>
     <string name="wifi_throttling_off">Регулирането на Wi-Fi сканирането е деактивирано</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Бързият роуминг (802.11 k/v/r) не се поддържа</string>
+    <string name="require_android_11_802_11_k_v_r">Откриването на бърз роуминг (802.11 k/v/r) изисква Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">Die WLAN-Scan-Drosselung ist aktiviert</string>
     <string name="wifi_throttling_off">Die WLAN-Scan-Drosselung ist deaktiviert</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Fast Roaming (802.11 k/v/r) wird nicht unterstützt</string>
+    <string name="require_android_11_802_11_k_v_r">Für die schnelle Roaming-Erkennung (802.11 k/v/r) ist Android 11 erforderlich</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">Ο περιορισμός σάρωσης Wi-Fi είναι ενεργοποιημένος</string>
     <string name="wifi_throttling_off">Ο περιορισμός σάρωσης Wi-Fi είναι απενεργοποιημένος</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Η γρήγορη περιαγωγή (802.11 k/v/r) δεν υποστηρίζεται</string>
+    <string name="require_android_11_802_11_k_v_r">Η ανίχνευση γρήγορης περιαγωγής (802.11 k/v/r) απαιτεί Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">La aceleración del escaneo de Wi-Fi está habilitada</string>
     <string name="wifi_throttling_off">La aceleración del escaneo de Wi-Fi está deshabilitada</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">La itinerancia rápida (802,11 k/v/r) no es compatible</string>
+    <string name="require_android_11_802_11_k_v_r">La detección de roaming rápido (802.11 k/v/r) requiere Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">La limitation de l\'analyse Wi-Fi est activée</string>
     <string name="wifi_throttling_off">La limitation de l\'analyse Wi-Fi est désactivée</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">L\'itinérance rapide (802.11 k/v/r) n\'est pas prise en charge</string>
+    <string name="require_android_11_802_11_k_v_r">La détection d\'itinérance rapide (802.11 k/v/r) nécessite Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">La limitazione della scansione Wi-Fi è abilitata</string>
     <string name="wifi_throttling_off">La limitazione della scansione Wi-Fi è disabilitata</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Il roaming veloce (802.11 k/v/r) non è supportato</string>
+    <string name="require_android_11_802_11_k_v_r">Il rilevamento del roaming veloce (802.11 k/v/r) richiede Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,4 +127,9 @@
     <string name="wifi_throttling_on">Wi-Fi スキャンのスロットルが有効になっています</string>
     <string name="wifi_throttling_off">Wi-Fi スキャンのスロットリングが無効になっています</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">高速ローミング(802.11 k/v/r)はサポートされていません</string>
+    <string name="require_android_11_802_11_k_v_r">高速ローミング（802.11 k/v/r）の検出には Android 11 が必要です</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -127,4 +127,9 @@
     <string name="wifi_throttling_on">Wi-Fi-scanbeperking is ingeschakeld</string>
     <string name="wifi_throttling_off">Wi-Fi-scanbeperking is uitgeschakeld</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Snelle roaming (802.11 k/v/r) wordt niet ondersteund</string>
+    <string name="require_android_11_802_11_k_v_r">Voor snelle roaming(802.11 k/v/r)-detectie is Android 11 vereist</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">Ograniczanie skanowania Wi-Fi jest włączone</string>
     <string name="wifi_throttling_off">Ograniczanie skanowania Wi-Fi jest wyłączone</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Szybki roaming (802.11 k/v/r) nie jest obsługiwany</string>
+    <string name="require_android_11_802_11_k_v_r">Wykrywanie szybkiego roamingu (802.11 k/v/r) wymaga systemu Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">A otimização da verificação de Wi-Fi está ativada</string>
     <string name="wifi_throttling_off">A otimização da verificação de Wi-Fi está desativada</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Roaming rápido (802.11 k/v/r) não é compatível</string>
+    <string name="require_android_11_802_11_k_v_r">A detecção de roaming rápido (802.11 k/v/r) requer Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">Регулирование сканирования Wi-Fi включено</string>
     <string name="wifi_throttling_off">Регулирование сканирования Wi-Fi отключено</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Быстрый роуминг (802.11 k/v/r) не поддерживается.</string>
+    <string name="require_android_11_802_11_k_v_r">Для обнаружения быстрого роуминга (802.11 k/v/r) требуется Android 11.</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -132,4 +132,9 @@
     <string name="wifi_throttling_on">Wi-Fi tarama kısıtlaması etkin</string>
     <string name="wifi_throttling_off">Wi-Fi tarama kısıtlaması devre dışı</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Hızlı Dolaşım (802.11 k/v/r) desteklenmez</string>
+    <string name="require_android_11_802_11_k_v_r">Hızlı Dolaşım (802.11 k/v/r) tespiti Android 11 gerektirir</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -127,4 +127,9 @@
     <string name="wifi_throttling_on">Регулювання сканування Wi-Fi увімкнено</string>
     <string name="wifi_throttling_off">Регулювання сканування Wi-Fi вимкнено</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">Швидкий роумінг (802.11 k/v/r) не підтримується</string>
+    <string name="require_android_11_802_11_k_v_r">Для виявлення швидкого роумінгу (802.11 k/v/r) потрібен Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -128,4 +128,9 @@
     <string name="wifi_throttling_on">Wi-Fi 扫描限制已启用</string>
     <string name="wifi_throttling_off">Wi-Fi 扫描限制已禁用</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">不支持 802.11 k/v/r</string>
+    <string name="require_android_11_802_11_k_v_r">快速漫游协议(802.11 k/v/r)的检测需要Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -130,4 +130,9 @@
     <string name="wifi_throttling_on">Wi-Fi 掃描限制已啟用</string>
     <string name="wifi_throttling_off">Wi-Fi 掃描限制已停用</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r">不支援快速漫遊 (802.11 k/v/r)</string>
+    <string name="require_android_11_802_11_k_v_r">快速漫遊 (802.11 k/v/r) 偵測需要 Android 11</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,6 +257,7 @@
     <!-- wifi throttling end -->
 
     <!-- fast roaming start -->
-    <string name="unsupported_802_11_k_v_r" translatable="false">UNSUPPORTED 802.11 k/v/r</string>
+    <string name="unsupported_802_11_k_v_r">Fast Roaming(802.11 k/v/r) is unsupported</string>
+    <string name="require_android_11_802_11_k_v_r">Fast Roaming(802.11 k/v/r) detection requires Android 11</string>
     <!-- fast roaming end -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,4 +255,8 @@
     <string name="wifi_throttling_on">Wi-Fi scan throttling is enabled</string>
     <string name="wifi_throttling_off">Wi-Fi scan throttling is disabled</string>
     <!-- wifi throttling end -->
+
+    <!-- fast roaming start -->
+    <string name="unsupported_802_11_k_v_r" translatable="false">UNSUPPORTED 802.11 k/v/r</string>
+    <!-- fast roaming end -->
 </resources>

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetailTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetailTest.kt
@@ -360,6 +360,17 @@ class AccessPointDetailTest {
         validateTextViewValue(actual, expectedFastRoaming, R.id.fastRoaming)
     }
 
+    @Test
+    fun testMakeViewDetailedFastRoamingMinVersionR() {
+        // setup
+        val wiFiDetail = withWiFiDetail(fastRoaming = listOf(FastRoaming.REQUIRE_ANDROID_R))
+        // execute
+        val actual = fixture.makeViewDetailed(wiFiDetail)
+        val expectedFastRoaming = actual.context.getString(R.string.require_android_11_802_11_k_v_r)
+        // validate
+        validateTextViewValue(actual, expectedFastRoaming, R.id.fastRoaming)
+    }
+
     private fun withWiFiDetail(
         ssid: String = "SSID",
         wiFiAdditional: WiFiAdditional = WiFiAdditional.EMPTY,

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetailTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/accesspoint/AccessPointDetailTest.kt
@@ -349,16 +349,28 @@ class AccessPointDetailTest {
         validateTextViewValue(actual, expectedTimestamp, R.id.timestamp)
     }
 
+    @Test
+    fun testMakeViewDetailedWithFastRoaming() {
+        // setup
+        val wiFiDetail = withWiFiDetail(fastRoaming = listOf(FastRoaming.K, FastRoaming.V, FastRoaming.R))
+        val expectedFastRoaming = "[802.11k][802.11v][802.11r]"
+        // execute
+        val actual = fixture.makeViewDetailed(wiFiDetail)
+        // validate
+        validateTextViewValue(actual, expectedFastRoaming, R.id.fastRoaming)
+    }
+
     private fun withWiFiDetail(
         ssid: String = "SSID",
         wiFiAdditional: WiFiAdditional = WiFiAdditional.EMPTY,
         is80211mc: Boolean = false,
-        timestamp: Long = 1000000
+        timestamp: Long = 1000000,
+        fastRoaming: List<FastRoaming> = listOf()
     ): WiFiDetail =
         WiFiDetail(
             WiFiIdentifier(ssid, "BSSID"),
             WiFiSecurity("[WPS-capabilities][WPA2-XYZ][XYZ-FT]", WiFiSecurityTypeTest.All),
-            WiFiSignal(1, 1, WiFiWidth.MHZ_40, 2, is80211mc, WiFiStandard.AC, timestamp),
+            WiFiSignal(1, 1, WiFiWidth.MHZ_40, 2, is80211mc, WiFiStandard.AC, timestamp, fastRoaming),
             wiFiAdditional
         )
 
@@ -382,6 +394,7 @@ class AccessPointDetailTest {
             validateTextViewValue(view, expectedWiFiStandard, R.id.wiFiStandard)
             val expectedWiFiBand = view.context.getString(wiFiSignal.wiFiBand.textResource)
             validateTextViewValue(view, expectedWiFiBand, R.id.wiFiBand)
+            validateTextViewValue(view, view.context.getString(R.string.unsupported_802_11_k_v_r), R.id.fastRoaming)
         }
     }
 

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoamingTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoamingTest.kt
@@ -1,0 +1,72 @@
+/*
+ * WiFiAnalyzer
+ * Copyright (C) 2015 - 2024 VREM Software Development <VREMSoftwareDevelopment@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+package com.vrem.wifianalyzer.wifi.model
+
+import android.net.wifi.ScanResult
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.ByteBuffer
+
+class FastRoamingTest {
+
+    private val withoutFastRoaming = listOf(
+        mockInformationElement(0, 0, byteArrayOf()),
+        mockInformationElement(WiFiSignal.RM_ENABLED_CAPABILITIES_IE, 0, ByteArray(0)),
+        mockInformationElement(WiFiSignal.EXTENDED_CAPABILITIES_IE, 0, ByteArray(0)),
+        mockInformationElement(WiFiSignal.RM_ENABLED_CAPABILITIES_IE, 0, ByteArray(5)),
+        mockInformationElement(WiFiSignal.EXTENDED_CAPABILITIES_IE, 0, ByteArray(3)),
+    )
+    private val withFastRoaming = listOf(
+        mockInformationElement(
+            WiFiSignal.RM_ENABLED_CAPABILITIES_IE,
+            0,
+            byteArrayOf(0x7F, 0, 0, 0, 0)
+        ),
+        mockInformationElement(WiFiSignal.EXTENDED_CAPABILITIES_IE, 0, byteArrayOf(0, 0, 0x7F)),
+        mockInformationElement(WiFiSignal.MOBILE_DOMAIN_IE, 0, ByteArray(5)),
+    )
+
+    @Test
+    fun testFastRoaming() {
+        // execute
+        val actual = withFastRoaming.map { FastRoaming.transformOrNull(it) }
+        // validate
+        assertEquals(listOf(FastRoaming.K, FastRoaming.V, FastRoaming.R), actual)
+    }
+
+    @Test
+    fun testNoFastRoaming() {
+        // execute
+        val actual = withoutFastRoaming.map { FastRoaming.transformOrNull(it) }
+        // validate
+        assertEquals(List(5) { null }, actual)
+    }
+
+    private fun mockInformationElement(id: Int, idExt: Int, bytes: ByteArray)
+            : ScanResult.InformationElement {
+        return mock<ScanResult.InformationElement>().apply {
+            doReturn(id).whenever(this).id
+            doReturn(idExt).whenever(this).idExt
+            doReturn(ByteBuffer.wrap(bytes).asReadOnlyBuffer()).whenever(this).bytes
+        }
+    }
+
+}

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoamingTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/FastRoamingTest.kt
@@ -47,7 +47,7 @@ class FastRoamingTest {
     @Test
     fun testFastRoaming() {
         // execute
-        val actual = withFastRoaming.map { FastRoaming.transformOrNull(it) }
+        val actual = withFastRoaming.map { FastRoaming.transform(it) }
         // validate
         assertEquals(listOf(FastRoaming.K, FastRoaming.V, FastRoaming.R), actual)
     }
@@ -55,9 +55,9 @@ class FastRoamingTest {
     @Test
     fun testNoFastRoaming() {
         // execute
-        val actual = withoutFastRoaming.map { FastRoaming.transformOrNull(it) }
+        val actual = withoutFastRoaming.map { FastRoaming.transform(it) }
         // validate
-        assertEquals(List(5) { null }, actual)
+        assertEquals(List(5) { FastRoaming.ILLEGAL_ATTR }, actual)
     }
 
     private fun mockInformationElement(id: Int, idExt: Int, bytes: ByteArray)

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
@@ -193,7 +193,7 @@ class TransformerTest {
         // execute
         val actual = fixture.fastRoaming(scanResult1)
         // validate
-        assertEquals(listOf<FastRoaming>(),  actual)
+        assertEquals(listOf(FastRoaming.REQUIRE_ANDROID_R),  actual)
         verify(fixture).minVersionR()
     }
 

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
@@ -47,6 +47,8 @@ import java.nio.ByteBuffer
 class TransformerTest {
     private val withoutFastRoaming = listOf(
         mockInformationElement(0, 0, byteArrayOf()),
+        mockInformationElement(RM_ENABLED_CAPABILITIES_IE, 0, ByteArray(5)),
+        mockInformationElement(EXTENDED_CAPABILITIES_IE, 0, ByteArray(3)),
     )
     private val withFastRoaming = listOf(
         mockInformationElement(RM_ENABLED_CAPABILITIES_IE, 0, byteArrayOf(0x7F, 0, 0, 0, 0)),

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
@@ -34,6 +34,8 @@ import java.nio.ByteBuffer
 class TransformerTest {
     private val withoutFastRoaming = listOf(
         mockInformationElement(0, 0, byteArrayOf()),
+        mockInformationElement(RM_ENABLED_CAPABILITIES_IE, 0, ByteArray(0)),
+        mockInformationElement(EXTENDED_CAPABILITIES_IE, 0, ByteArray(0)),
         mockInformationElement(RM_ENABLED_CAPABILITIES_IE, 0, ByteArray(5)),
         mockInformationElement(EXTENDED_CAPABILITIES_IE, 0, ByteArray(3)),
     )


### PR DESCRIPTION
**What does this implement/fix? Please describe.**

Support fast roaming protocol (802.11 k/v/r).

![Screenshot_2024-01-20-10-09-03-346_com vrem wifianalyzer BETA](https://github.com/VREMSoftwareDevelopment/WiFiAnalyzer/assets/9478918/72e7d474-6b2a-498e-bb1c-4f9dbe499a91)

![222](https://github.com/VREMSoftwareDevelopment/WiFiAnalyzer/assets/9478918/6690f84a-1e87-4c43-aac9-4a1befb90ddc)

**Additional context**

| feature | Element | check bit |
|---|---|---|
| 802.11k | RM Enabled Capabilities | Neighbor Report |
| 802.11v | Extended Capabilities | BSS Transition |
| 802.11r | Mobile Domain | any |

> Reference: 802.11-2012 8.4.2 Information elements

**Where has this been tested?**

Yes, with unittest and on-board test

- Operating System: Android 9/10/12
- Platform: Redmi 8A, Samsung A60, Redmi 12 Turbo
- Target Platform: Android
- Toolchain Version: Any
- SDK Version: 33
