### PR TITLE
add wifi7 320Mhz support

### DIFF
--- a/app/build.properties
+++ b/app/build.properties
@@ -1,6 +1,6 @@
 #Build Properties
-#Mon Mar 10 20:50:42 CST 2025
-version_build=8
+#Tue Mar 11 02:41:10 CST 2025
+version_build=12
 version_major=3
 version_minor=1
 version_patch=4

--- a/app/build.properties
+++ b/app/build.properties
@@ -1,6 +1,6 @@
 #Build Properties
-#Tue Mar 11 02:41:10 CST 2025
-version_build=12
+#Sun Mar 16 19:19:38 CST 2025
+version_build=14
 version_major=3
 version_minor=1
 version_patch=4

--- a/app/build.properties
+++ b/app/build.properties
@@ -1,6 +1,6 @@
 #Build Properties
-#Sun Mar 16 19:19:38 CST 2025
-version_build=14
+#Sun Mar 16 22:49:06 CST 2025
+version_build=17
 version_major=3
 version_minor=1
 version_patch=4

--- a/app/build.properties
+++ b/app/build.properties
@@ -1,6 +1,6 @@
 #Build Properties
-#Sat Mar 08 09:09:08 EST 2025
-version_build=5
+#Mon Mar 10 20:50:42 CST 2025
+version_build=8
 version_major=3
 version_minor=1
 version_patch=4

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6.kt
@@ -36,14 +36,13 @@ class WiFiChannelsGHZ6 : WiFiChannels(RANGE, SETS) {
         if (inRange(frequency)) wiFiChannel(frequency, wiFiChannelPair) else WiFiChannel.UNKNOWN
 
     companion object {
-        val SET1 = WiFiChannelPair(WiFiChannel(1, 5955), WiFiChannel(29, 6095))
-        val SET2 = WiFiChannelPair(WiFiChannel(33, 6115), WiFiChannel(61, 6255))
-        val SET3 = WiFiChannelPair(WiFiChannel(65, 6275), WiFiChannel(93, 6415))
-        val SET4 = WiFiChannelPair(WiFiChannel(97, 6435), WiFiChannel(125, 6575))
-        val SET5 = WiFiChannelPair(WiFiChannel(129, 6595), WiFiChannel(157, 6735))
-        val SET6 = WiFiChannelPair(WiFiChannel(161, 6755), WiFiChannel(189, 6895))
-        val SET7 = WiFiChannelPair(WiFiChannel(193, 6915), WiFiChannel(229, 7095))
-        val SETS = listOf(SET1, SET2, SET3, SET4, SET5, SET6, SET7)
+        val SET1 = WiFiChannelPair(WiFiChannel(1, 5955), WiFiChannel(65, 6275))
+        val SET2 = WiFiChannelPair(WiFiChannel(33, 6115), WiFiChannel(97, 6435))
+        val SET3 = WiFiChannelPair(WiFiChannel(65, 6275), WiFiChannel(129, 6595))
+        val SET4 = WiFiChannelPair(WiFiChannel(97, 6435), WiFiChannel(161, 6755))
+        val SET5 = WiFiChannelPair(WiFiChannel(129, 6595), WiFiChannel(189, 6895))
+        val SET6 = WiFiChannelPair(WiFiChannel(161, 6755), WiFiChannel(233, 7115))
+        val SETS = listOf(SET1, SET2, SET3, SET4, SET5, SET6)
         private val RANGE = WiFiRange(5925, 7125)
     }
 }

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6.kt
@@ -41,7 +41,7 @@ class WiFiChannelsGHZ6 : WiFiChannels(RANGE, SETS) {
         val SET3 = WiFiChannelPair(WiFiChannel(65, 6275), WiFiChannel(129, 6595))
         val SET4 = WiFiChannelPair(WiFiChannel(97, 6435), WiFiChannel(161, 6755))
         val SET5 = WiFiChannelPair(WiFiChannel(129, 6595), WiFiChannel(189, 6895))
-        val SET6 = WiFiChannelPair(WiFiChannel(161, 6755), WiFiChannel(233, 7115))
+        val SET6 = WiFiChannelPair(WiFiChannel(161, 6755), WiFiChannel(229, 7095))
         val SETS = listOf(SET1, SET2, SET3, SET4, SET5, SET6)
         private val RANGE = WiFiRange(5925, 7125)
     }

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigation.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigation.kt
@@ -54,8 +54,7 @@ internal val navigationGHZ6Lines = mapOf(
     R.id.graphNavigationLine2 to mapOf(
         R.id.graphNavigationSet4 to WiFiChannelsGHZ6.SET4,
         R.id.graphNavigationSet5 to WiFiChannelsGHZ6.SET5,
-        R.id.graphNavigationSet6 to WiFiChannelsGHZ6.SET6,
-        R.id.graphNavigationSet7 to WiFiChannelsGHZ6.SET7
+        R.id.graphNavigationSet6 to WiFiChannelsGHZ6.SET6
     )
 )
 

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphView.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphView.kt
@@ -53,11 +53,15 @@ internal fun makeGraphView(
     wiFiChannelPair: WiFiChannelPair
 ): GraphView {
     val resources = mainContext.resources
-    return GraphViewBuilder(wiFiChannelPair.numX(), graphMaximumY, themeStyle, true)
+    val gridView = GraphViewBuilder(wiFiChannelPair.numX(), graphMaximumY, themeStyle, true)
         .setLabelFormatter(ChannelAxisLabel(wiFiBand, wiFiChannelPair))
         .setVerticalTitle(resources.getString(R.string.graph_axis_y))
         .setHorizontalTitle(resources.getString(R.string.graph_channel_axis_x))
         .build(mainContext.context)
+    if(wiFiBand.ghz6) {
+        gridView.gridLabelRenderer.setHorizontalLabelsAngle(45)
+    }
+    return  gridView;
 }
 
 internal fun makeDefaultSeries(frequencyEnd: Int, minX: Int): TitleLineGraphSeries<GraphDataPoint> {

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidth.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidth.kt
@@ -22,11 +22,11 @@ import kotlin.math.abs
 
 typealias ChannelWidth = Int
 
-typealias CalculateCenter = (primary: Int, center: Int) -> Int
+typealias CalculateCenter = (primary: Int, center: Int, center1: Int) -> Int
 
-internal val calculateCenter20: CalculateCenter = { primary, _ -> primary }
+internal val calculateCenter20: CalculateCenter = { primary, _ ,_ -> primary }
 
-internal val calculateCenter40: CalculateCenter = { primary, center ->
+internal val calculateCenter40: CalculateCenter = { primary, center, _ ->
     if (abs(primary - center) >= WiFiWidth.MHZ_40.frequencyWidthHalf) {
         (primary + center) / 2
     } else {
@@ -34,9 +34,9 @@ internal val calculateCenter40: CalculateCenter = { primary, center ->
     }
 }
 
-internal val calculateCenter80: CalculateCenter = { _, center -> center }
+internal val calculateCenter80: CalculateCenter = { _, center, _ -> center }
 
-internal val calculateCenter160: CalculateCenter = { primary, center ->
+internal val calculateCenter160: CalculateCenter = { primary, center, _ ->
     when (primary) {
         // 5GHz
         in 5170..5330 -> 5250
@@ -53,13 +53,15 @@ internal val calculateCenter160: CalculateCenter = { primary, center ->
         else -> center
     }
 }
+internal val calculateCenter320: CalculateCenter = { _, _, center1 ->center1 }
 
 enum class WiFiWidth(val channelWidth: ChannelWidth, val frequencyWidth: Int, val guardBand: Int, val calculateCenter: CalculateCenter) {
     MHZ_20(ScanResult.CHANNEL_WIDTH_20MHZ, 20, 2, calculateCenter20),
     MHZ_40(ScanResult.CHANNEL_WIDTH_40MHZ, 40, 3, calculateCenter40),
     MHZ_80(ScanResult.CHANNEL_WIDTH_80MHZ, 80, 3, calculateCenter80),
     MHZ_160(ScanResult.CHANNEL_WIDTH_160MHZ, 160, 3, calculateCenter160),
-    MHZ_80_PLUS(ScanResult.CHANNEL_WIDTH_80MHZ_PLUS_MHZ, 80, 3, calculateCenter80);
+    MHZ_80_PLUS(ScanResult.CHANNEL_WIDTH_80MHZ_PLUS_MHZ, 80, 3, calculateCenter80),
+    MHZ_320(ScanResult.CHANNEL_WIDTH_320MHZ, 320, 3, calculateCenter320);
 
     val frequencyWidthHalf: Int = frequencyWidth / 2
 

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
@@ -60,6 +60,7 @@ internal class Transformer(private val cache: Cache) {
 
     private fun transform(cacheResult: CacheResult): WiFiDetail {
         val scanResult = cacheResult.scanResult
+
         val wiFiWidth = WiFiWidth.findOne(scanResult.channelWidth)
         val centerFrequency = wiFiWidth.calculateCenter(scanResult.frequency, scanResult.centerFreq0, scanResult.centerFreq1)
         val mc80211 = scanResult.is80211mcResponder

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Transformer.kt
@@ -61,7 +61,7 @@ internal class Transformer(private val cache: Cache) {
     private fun transform(cacheResult: CacheResult): WiFiDetail {
         val scanResult = cacheResult.scanResult
         val wiFiWidth = WiFiWidth.findOne(scanResult.channelWidth)
-        val centerFrequency = wiFiWidth.calculateCenter(scanResult.frequency, scanResult.centerFreq0)
+        val centerFrequency = wiFiWidth.calculateCenter(scanResult.frequency, scanResult.centerFreq0, scanResult.centerFreq1)
         val mc80211 = scanResult.is80211mcResponder
         val wiFiStandard = WiFiStandard.findOne(scanResult)
         val fastRoaming = FastRoaming.find(scanResult)

--- a/app/src/main/res/layout/graph_content.xml
+++ b/app/src/main/res/layout/graph_content.xml
@@ -123,17 +123,6 @@
                     android:minHeight="0dp"
                     tools:text="600-699" />
 
-                <Button
-                    style="?android:attr/buttonBarButtonStyle"
-                    android:id="@+id/graphNavigationSet7"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/activity_vertical_half_margin"
-                    android:layout_weight="1"
-                    android:background="@null"
-                    android:minWidth="0dp"
-                    android:minHeight="0dp"
-                    tools:text="700-799" />
             </LinearLayout>
         </LinearLayout>
 

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6Test.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6Test.kt
@@ -56,7 +56,7 @@ class WiFiChannelsGHZ6Test {
     @Test
     fun wiFiChannelByChannel() {
         assertThat(fixture.wiFiChannelByChannel(1).frequency).isEqualTo(5955)
-        assertThat(fixture.wiFiChannelByChannel(93).frequency).isEqualTo(6415)
+        assertThat(fixture.wiFiChannelByChannel(97).frequency).isEqualTo(6435)
     }
 
     @Test
@@ -72,7 +72,7 @@ class WiFiChannelsGHZ6Test {
 
     @Test
     fun wiFiChannelLast() {
-        assertThat(fixture.wiFiChannelLast().channel).isEqualTo(229)
+        assertThat(fixture.wiFiChannelLast().channel).isEqualTo(233)
     }
 
     @Test
@@ -85,14 +85,13 @@ class WiFiChannelsGHZ6Test {
     @Test
     fun wiFiChannelPairs() {
         val wiFiChannelPairs: List<WiFiChannelPair> = fixture.wiFiChannelPairs()
-        assertThat(wiFiChannelPairs).hasSize(7)
-        validatePair(1, 29, wiFiChannelPairs[0])
-        validatePair(33, 61, wiFiChannelPairs[1])
-        validatePair(65, 93, wiFiChannelPairs[2])
-        validatePair(97, 125, wiFiChannelPairs[3])
-        validatePair(129, 157, wiFiChannelPairs[4])
-        validatePair(161, 189, wiFiChannelPairs[5])
-        validatePair(193, 229, wiFiChannelPairs[6])
+        assertThat(wiFiChannelPairs).hasSize(6)
+        validatePair(1, 65, wiFiChannelPairs[0])
+        validatePair(33, 97, wiFiChannelPairs[1])
+        validatePair(65, 129, wiFiChannelPairs[2])
+        validatePair(97, 161, wiFiChannelPairs[3])
+        validatePair(129, 189, wiFiChannelPairs[4])
+        validatePair(161, 233, wiFiChannelPairs[5])
     }
 
     private fun validatePair(expectedFirst: Int, expectedSecond: Int, pair: WiFiChannelPair) {

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6Test.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6Test.kt
@@ -72,7 +72,7 @@ class WiFiChannelsGHZ6Test {
 
     @Test
     fun wiFiChannelLast() {
-        assertThat(fixture.wiFiChannelLast().channel).isEqualTo(233)
+        assertThat(fixture.wiFiChannelLast().channel).isEqualTo(229)
     }
 
     @Test
@@ -91,7 +91,7 @@ class WiFiChannelsGHZ6Test {
         validatePair(65, 129, wiFiChannelPairs[2])
         validatePair(97, 161, wiFiChannelPairs[3])
         validatePair(129, 189, wiFiChannelPairs[4])
-        validatePair(161, 233, wiFiChannelPairs[5])
+        validatePair(161, 229, wiFiChannelPairs[5])
     }
 
     private fun validatePair(expectedFirst: Int, expectedSecond: Int, pair: WiFiChannelPair) {

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6Test.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/band/WiFiChannelsGHZ6Test.kt
@@ -50,7 +50,7 @@ class WiFiChannelsGHZ6Test {
     @Test
     fun wiFiChannelByFrequencyNotFound() {
         assertThat(fixture.wiFiChannelByFrequency(5952)).isEqualTo(WiFiChannel.UNKNOWN)
-        assertThat(fixture.wiFiChannelByFrequency(6418)).isEqualTo(WiFiChannel.UNKNOWN)
+        assertThat(fixture.wiFiChannelByFrequency(7098)).isEqualTo(WiFiChannel.UNKNOWN)
     }
 
     @Test
@@ -62,7 +62,7 @@ class WiFiChannelsGHZ6Test {
     @Test
     fun wiFiChannelByChannelNotFound() {
         assertThat(fixture.wiFiChannelByChannel(0)).isEqualTo(WiFiChannel.UNKNOWN)
-        assertThat(fixture.wiFiChannelByChannel(94)).isEqualTo(WiFiChannel.UNKNOWN)
+        assertThat(fixture.wiFiChannelByChannel(230)).isEqualTo(WiFiChannel.UNKNOWN)
     }
 
     @Test
@@ -77,9 +77,9 @@ class WiFiChannelsGHZ6Test {
 
     @Test
     fun wiFiChannelPair() {
-        validatePair(1, 29, fixture.wiFiChannelPairFirst(Locale.US.country))
-        validatePair(1, 29, fixture.wiFiChannelPairFirst(String.EMPTY))
-        validatePair(1, 29, fixture.wiFiChannelPairFirst("XYZ"))
+        validatePair(1, 65, fixture.wiFiChannelPairFirst(Locale.US.country))
+        validatePair(1, 65, fixture.wiFiChannelPairFirst(String.EMPTY))
+        validatePair(1, 65, fixture.wiFiChannelPairFirst("XYZ"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigationTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigationTest.kt
@@ -153,7 +153,7 @@ class ChannelGraphNavigationTest {
     @Test
     fun navigationGHZ6Line2() {
         val line2 = navigationGHZ6Lines[R.id.graphNavigationLine2]!!
-        assertThat(line2).hasSize(4)
+        assertThat(line2).hasSize(3)
         assertThat(WiFiChannelsGHZ6.SET4).isEqualTo(line2[R.id.graphNavigationSet4])
         assertThat(WiFiChannelsGHZ6.SET5).isEqualTo(line2[R.id.graphNavigationSet5])
         assertThat(WiFiChannelsGHZ6.SET6).isEqualTo(line2[R.id.graphNavigationSet6])

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigationTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/channelgraph/ChannelGraphNavigationTest.kt
@@ -157,7 +157,6 @@ class ChannelGraphNavigationTest {
         assertThat(WiFiChannelsGHZ6.SET4).isEqualTo(line2[R.id.graphNavigationSet4])
         assertThat(WiFiChannelsGHZ6.SET5).isEqualTo(line2[R.id.graphNavigationSet5])
         assertThat(WiFiChannelsGHZ6.SET6).isEqualTo(line2[R.id.graphNavigationSet6])
-        assertThat(WiFiChannelsGHZ6.SET7).isEqualTo(line2[R.id.graphNavigationSet7])
     }
 
     private fun whenLines(navigationLines: NavigationLines) {

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidthTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidthTest.kt
@@ -26,7 +26,7 @@ class WiFiWidthTest {
 
     @Test
     fun width() {
-        assertThat(WiFiWidth.entries.size).isEqualTo(5)
+        assertThat(WiFiWidth.entries.size).isEqualTo(6)
     }
 
     @Test
@@ -56,7 +56,7 @@ class WiFiWidthTest {
         assertThat(WiFiWidth.MHZ_80.frequencyWidthHalf).isEqualTo(40)
         assertThat(WiFiWidth.MHZ_160.frequencyWidthHalf).isEqualTo(80)
         assertThat(WiFiWidth.MHZ_80_PLUS.frequencyWidthHalf).isEqualTo(40)
-        assertThat(WiFiWidth.MHZ_320.frequencyWidthHalf).isEqualTo(320)
+        assertThat(WiFiWidth.MHZ_320.frequencyWidthHalf).isEqualTo(160)
     }
 
     @Test
@@ -78,7 +78,7 @@ class WiFiWidthTest {
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_320MHZ)).isEqualTo(WiFiWidth.MHZ_320)
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_80MHZ_PLUS_MHZ)).isEqualTo(WiFiWidth.MHZ_80_PLUS)
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_20MHZ - 1)).isEqualTo(WiFiWidth.MHZ_20)
-        assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_80MHZ_PLUS_MHZ + 1)).isEqualTo(WiFiWidth.MHZ_20)
+        assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_320MHZ + 1)).isEqualTo(WiFiWidth.MHZ_20)
     }
 
     @Test

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidthTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidthTest.kt
@@ -86,9 +86,9 @@ class WiFiWidthTest {
         // setup
         val expected = 35
         // execute & validate
-        assertThat(calculateCenter20(expected, Int.MIN_VALUE)).isEqualTo(expected)
-        assertThat(calculateCenter20(expected, 0)).isEqualTo(expected)
-        assertThat(calculateCenter20(expected, Int.MAX_VALUE)).isEqualTo(expected)
+        assertThat(calculateCenter20(expected, Int.MIN_VALUE,Int.MIN_VALUE)).isEqualTo(expected)
+        assertThat(calculateCenter20(expected, 0,Int.MIN_VALUE)).isEqualTo(expected)
+        assertThat(calculateCenter20(expected, Int.MAX_VALUE,Int.MIN_VALUE)).isEqualTo(expected)
     }
 
     @Test
@@ -97,8 +97,8 @@ class WiFiWidthTest {
         val primary = 10
         val center = primary + WiFiWidth.MHZ_40.frequencyWidthHalf - 1
         // execute & validate
-        assertThat(calculateCenter40(primary, center)).isEqualTo(center)
-        assertThat(calculateCenter40(center, primary)).isEqualTo(primary)
+        assertThat(calculateCenter40(primary, center,Int.MIN_VALUE)).isEqualTo(center)
+        assertThat(calculateCenter40(center, primary,Int.MIN_VALUE)).isEqualTo(primary)
     }
 
     @Test
@@ -108,8 +108,8 @@ class WiFiWidthTest {
         val center = primary + WiFiWidth.MHZ_40.frequencyWidthHalf
         val expected = (primary + center) / 2
         // execute & validate
-        assertThat(calculateCenter40(primary, center)).isEqualTo(expected)
-        assertThat(calculateCenter40(center, primary)).isEqualTo(expected)
+        assertThat(calculateCenter40(primary, center,Int.MIN_VALUE)).isEqualTo(expected)
+        assertThat(calculateCenter40(center, primary,Int.MIN_VALUE)).isEqualTo(expected)
     }
 
     @Test
@@ -117,20 +117,20 @@ class WiFiWidthTest {
         // setup
         val expected = 35
         // execute & validate
-        assertThat(calculateCenter80(Int.MIN_VALUE, expected)).isEqualTo(expected)
-        assertThat(calculateCenter80(0, expected)).isEqualTo(expected)
-        assertThat(calculateCenter80(Int.MAX_VALUE, expected)).isEqualTo(expected)
+        assertThat(calculateCenter80(Int.MIN_VALUE, expected,Int.MIN_VALUE)).isEqualTo(expected)
+        assertThat(calculateCenter80(0, expected,Int.MIN_VALUE)).isEqualTo(expected)
+        assertThat(calculateCenter80(Int.MAX_VALUE, expected,Int.MIN_VALUE)).isEqualTo(expected)
     }
 
     @Test
     fun calculateCenter160Invalid() {
         // execute & validate
-        assertThat(calculateCenter160(5169, Int.MIN_VALUE)).isEqualTo(Int.MIN_VALUE)
-        assertThat(calculateCenter160(5169, 0)).isEqualTo(0)
-        assertThat(calculateCenter160(5169, Int.MAX_VALUE)).isEqualTo(Int.MAX_VALUE)
-        assertThat(calculateCenter160(5896, Int.MIN_VALUE)).isEqualTo(Int.MIN_VALUE)
-        assertThat(calculateCenter160(5896, 0)).isEqualTo(0)
-        assertThat(calculateCenter160(5896, Int.MAX_VALUE)).isEqualTo(Int.MAX_VALUE)
+        assertThat(calculateCenter160(5169, Int.MIN_VALUE,Int.MIN_VALUE)).isEqualTo(Int.MIN_VALUE)
+        assertThat(calculateCenter160(5169, 0,Int.MIN_VALUE)).isEqualTo(0)
+        assertThat(calculateCenter160(5169, Int.MAX_VALUE,Int.MIN_VALUE)).isEqualTo(Int.MAX_VALUE)
+        assertThat(calculateCenter160(5896, Int.MIN_VALUE,Int.MIN_VALUE)).isEqualTo(Int.MIN_VALUE)
+        assertThat(calculateCenter160(5896, 0,Int.MIN_VALUE)).isEqualTo(0)
+        assertThat(calculateCenter160(5896, Int.MAX_VALUE,Int.MIN_VALUE)).isEqualTo(Int.MAX_VALUE)
     }
 
     @Test
@@ -141,12 +141,21 @@ class WiFiWidthTest {
         }
     }
 
+    @Test
+    fun calculateCenter320(){
+        // setup
+        val expected = 35
+        // execute & validate
+        assertThat(calculateCenter320(Int.MIN_VALUE,Int.MIN_VALUE, expected)).isEqualTo(expected)
+        assertThat(calculateCenter320(0,Int.MIN_VALUE, expected)).isEqualTo(expected)
+        assertThat(calculateCenter320(Int.MAX_VALUE,Int.MIN_VALUE, expected)).isEqualTo(expected)
+    }
     private fun validate(expected: Int, start: Int, end: Int) {
         // execute & validate
         for (value in start..end) {
-            assertThat(calculateCenter160(value, Int.MIN_VALUE)).isEqualTo(expected)
-            assertThat(calculateCenter160(value, 0)).isEqualTo(expected)
-            assertThat(calculateCenter160(value, Int.MAX_VALUE)).isEqualTo(expected)
+            assertThat(calculateCenter160(value, Int.MIN_VALUE,Int.MIN_VALUE)).isEqualTo(expected)
+            assertThat(calculateCenter160(value, 0,Int.MIN_VALUE)).isEqualTo(expected)
+            assertThat(calculateCenter160(value, Int.MAX_VALUE,Int.MIN_VALUE)).isEqualTo(expected)
         }
     }
 

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidthTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/model/WiFiWidthTest.kt
@@ -36,6 +36,7 @@ class WiFiWidthTest {
         assertThat(WiFiWidth.MHZ_80.calculateCenter.javaClass.isInstance(calculateCenter80)).isTrue()
         assertThat(WiFiWidth.MHZ_160.calculateCenter.javaClass.isInstance(calculateCenter160)).isTrue()
         assertThat(WiFiWidth.MHZ_80_PLUS.calculateCenter.javaClass.isInstance(calculateCenter80)).isTrue()
+        assertThat(WiFiWidth.MHZ_320.calculateCenter.javaClass.isInstance(calculateCenter320)).isTrue()
     }
 
     @Test
@@ -45,6 +46,7 @@ class WiFiWidthTest {
         assertThat(WiFiWidth.MHZ_80.frequencyWidth).isEqualTo(80)
         assertThat(WiFiWidth.MHZ_160.frequencyWidth).isEqualTo(160)
         assertThat(WiFiWidth.MHZ_80_PLUS.frequencyWidth).isEqualTo(80)
+        assertThat(WiFiWidth.MHZ_320.frequencyWidth).isEqualTo(320)
     }
 
     @Test
@@ -54,6 +56,7 @@ class WiFiWidthTest {
         assertThat(WiFiWidth.MHZ_80.frequencyWidthHalf).isEqualTo(40)
         assertThat(WiFiWidth.MHZ_160.frequencyWidthHalf).isEqualTo(80)
         assertThat(WiFiWidth.MHZ_80_PLUS.frequencyWidthHalf).isEqualTo(40)
+        assertThat(WiFiWidth.MHZ_320.frequencyWidthHalf).isEqualTo(320)
     }
 
     @Test
@@ -63,6 +66,7 @@ class WiFiWidthTest {
         assertThat(WiFiWidth.MHZ_80.guardBand).isEqualTo(3)
         assertThat(WiFiWidth.MHZ_160.guardBand).isEqualTo(3)
         assertThat(WiFiWidth.MHZ_80_PLUS.guardBand).isEqualTo(3)
+        assertThat(WiFiWidth.MHZ_320.guardBand).isEqualTo(3)
     }
 
     @Test
@@ -71,6 +75,7 @@ class WiFiWidthTest {
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_40MHZ)).isEqualTo(WiFiWidth.MHZ_40)
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_80MHZ)).isEqualTo(WiFiWidth.MHZ_80)
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_160MHZ)).isEqualTo(WiFiWidth.MHZ_160)
+        assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_320MHZ)).isEqualTo(WiFiWidth.MHZ_320)
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_80MHZ_PLUS_MHZ)).isEqualTo(WiFiWidth.MHZ_80_PLUS)
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_20MHZ - 1)).isEqualTo(WiFiWidth.MHZ_20)
         assertThat(WiFiWidth.findOne(ScanResult.CHANNEL_WIDTH_80MHZ_PLUS_MHZ + 1)).isEqualTo(WiFiWidth.MHZ_20)

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/scanner/TransformerTest.kt
@@ -153,6 +153,11 @@ class TransformerTest {
             WiFiWidth.MHZ_80 -> FREQUENCY + wiFiWidth.frequencyWidthHalf
             WiFiWidth.MHZ_160 -> FREQUENCY + wiFiWidth.frequencyWidth
             WiFiWidth.MHZ_80_PLUS -> FREQUENCY + wiFiWidth.frequencyWidthHalf
+            WiFiWidth.MHZ_320 -> FREQUENCY + wiFiWidth.frequencyWidthHalf
+        }
+        scanResult.centerFreq1 = when(wiFiWidth) {
+            WiFiWidth.MHZ_320 -> FREQUENCY + wiFiWidth.frequencyWidth
+            else -> -1
         }
         scanResult.level = LEVEL
         scanResult.channelWidth = wiFiWidth.ordinal


### PR DESCRIPTION
Thanks for sending a pull request!

[How to submit a pull request](https://github.com/VREMSoftwareDevelopment/WiFiAnalyzer/wiki/Pull-Request)

**What does this implement/fix? Please describe.**

- add 320Mhz support

**Does this close any currently open issues?**

- [475](https://github.com/VREMSoftwareDevelopment/WiFiAnalyzer/issues/475)

**Additional context**

- to avoid major UI change , I change the graph navigation set overlapped about same as 320Mhz channel as a temporary solution , also set label angle for 6Ghz band to avoid text overlapping
- the center freq of 320Mhz is correct reported in scanresult , but is at `centerFreq1` , tested with `Sony Xperia 1 VI` but this against  api description , I'm not sure it can be used
- for use  `centerFreq1` , add 3rd args to calculateCenter func
- for my country the 6Ghz band availability is very limited, I can only test channel 31 and 95

**Where has this been tested?**

Wifi 7 AP : Ubiquiti Unifi U7 Pro 
Client Device : Sony Xperia 1 VI 

![Screenshot_20250310-011612.png](https://github.com/user-attachments/assets/6587016d-4579-4a3f-b4f2-d56029ea352b)

