### PR TITLE
build: use a lint.xml file for granular control over lint behavior

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,7 @@ android {
         jvmTarget = "11"
     }
     lint {
-        disable 'GoogleAppIndexingWarning'
+        lintConfig = file("app/lint.xml")
     }
 }
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="GoogleAppIndexingWarning" severity="ignore" />
+
+     <!-- Translations are crowdsourced, we can't have 100% coverage at all times -->
+    <issue id="MissingTranslation" severity="ignore" />
+
+    <!-- Weblate doesn't handle these yet: https://github.com/WeblateOrg/weblate/issues/7520 -->
+    <issue id="MissingQuantity" severity="error">
+        <ignore path="src/main/res/values-cs" />
+        <ignore path="src/main/res/values-lt" />
+        <ignore path="src/main/res/values-sk" />
+    </issue>
+</lint>


### PR DESCRIPTION
allows us to ignore missingQuantity for specific languages, currently we have no plurals, though

also disabling missingTranslation