### PR TITLE
translation: remove some strings that may be potentially machine-gene…

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -73,7 +73,6 @@
     <string name="group_by_title">"Групиране точките за достъп по"</string>
     <string name="group_by_none">"Няма"</string>
     <string name="group_by_channel">"Канал"</string>
-    <string name="group_by_virtual">"Virtual"</string>
 
     <string name="connection_view_title">"Показване на връзката"</string>
     <string name="connection_view_complete">"Пълно"</string>
@@ -126,7 +125,6 @@
     <string name="filter_close">"Затвори"</string>
     <string name="filter_reset">"Нулирай"</string>
     <string name="filter_apply">"Приложи"</string>
-    <string name="filter_ssid_title">"SSID (различаващ главни от малки букви)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi диапазон"</string>
     <string name="filter_strength_title">"Сила на сигнала"</string>
     <string name="filter_security_title">"Защита"</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,7 +122,6 @@
     <string name="filter_close">"Schließen"</string>
     <string name="filter_reset">"Zurücksetzen"</string>
     <string name="filter_apply">"Anwenden"</string>
-    <string name="filter_ssid_title">"SSID (case-sensitiv)"</string>
     <string name="filter_wifi_band_title">"WLAN-Frequenzbänder"</string>
     <string name="filter_strength_title">"Signalstärke"</string>
     <string name="filter_security_title">"Sicherheit"</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -122,7 +122,6 @@
     <string name="filter_close">"Κλείσιμο"</string>
     <string name="filter_reset">"Επαναφορά"</string>
     <string name="filter_apply">"Εφαρμογή"</string>
-    <string name="filter_ssid_title">"SSID (διάκριση πεζών-κεφαλαίων)"</string>
     <string name="filter_wifi_band_title">"Ζώνη Wi-Fi"</string>
     <string name="filter_strength_title">"Ισχύς σήματος"</string>
     <string name="filter_security_title">"Ασφάλεια"</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -71,7 +71,6 @@
     <string name="group_by_title">"Raggruppa Access Points per"</string>
     <string name="group_by_none">"Non Raggruppare"</string>
     <string name="group_by_channel">"Canale"</string>
-    <string name="group_by_virtual">"Virtual"</string>
 
     <string name="connection_view_title">"Access Point connesso"</string>
     <string name="connection_view_complete">"Completo"</string>
@@ -122,7 +121,6 @@
     <string name="filter_close">"Chiudi"</string>
     <string name="filter_reset">"Resetta"</string>
     <string name="filter_apply">"Applica"</string>
-    <string name="filter_ssid_title">"SSID (sensibile alle maiuscole)"</string>
     <string name="filter_wifi_band_title">"Banda Wi-Fi"</string>
     <string name="filter_strength_title">"Potenza Segnale"</string>
     <string name="filter_security_title">"Sicurezza"</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -121,7 +121,6 @@
     <string name="filter_close">"閉じる"</string>
     <string name="filter_reset">"リセット"</string>
     <string name="filter_apply">"適用"</string>
-    <string name="filter_ssid_title">"SSID (ケース・センシティブ)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi バンド"</string>
     <string name="filter_strength_title">"信号の強さ"</string>
     <string name="filter_security_title">"セキュリティ"</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -121,7 +121,6 @@
     <string name="filter_close">"Sluiten"</string>
     <string name="filter_reset">"Resetten"</string>
     <string name="filter_apply">"Toepassen"</string>
-    <string name="filter_ssid_title">"SSID (hoofdlettergevoelig)"</string>
     <string name="filter_wifi_band_title">"Wifi-band"</string>
     <string name="filter_strength_title">"Signaalsterkte"</string>
     <string name="filter_security_title">"Beveiliging"</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -71,7 +71,6 @@
     <string name="group_by_title">"Группировка"</string>
     <string name="group_by_none">"Нет"</string>
     <string name="group_by_channel">"Канал"</string>
-    <string name="group_by_virtual">"Virtual"</string>
 
     <string name="connection_view_title">"Дисплей соединение"</string>
     <string name="connection_view_complete">"Полный"</string>
@@ -93,11 +92,9 @@
     <string name="theme_title">"Цветовая тема"</string>
     <string name="theme_dark">"Темная"</string>
     <string name="theme_light">"Светлая"</string>
-    <string name="theme_system">"Система"</string>
 
     <string name="wifi_off_on_exit_title">"Wi-Fi выключен при выходе"</string>
 
-    <string name="keep_screen_on_title">"Экран всегда включен"</string>
 
     <string name="language_title">"Язык"</string>
 
@@ -122,7 +119,6 @@
     <string name="filter_close">"Закрыть"</string>
     <string name="filter_reset">"Сброс"</string>
     <string name="filter_apply">"Применить"</string>
-    <string name="filter_ssid_title">"SSID (Чувствительность к регистру символов)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi диапазон"</string>
     <string name="filter_strength_title">"Уровень сигнала"</string>
     <string name="filter_security_title">"Безопасность"</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -126,8 +126,6 @@
     <string name="filter_close">"Kapat"</string>
     <string name="filter_reset">"Sıfırla"</string>
     <string name="filter_apply">"Uygula"</string>
-    <string name="filter_ssid_title">"SSID (harfe duyarlı)"</string>
-    <string name="filter_wifi_band_title">"Wi-Fi Bandı"</string>
     <string name="filter_strength_title">"Sinyal Gücü"</string>
     <string name="filter_security_title">"Güvenlik"</string>
     <!-- filter end -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -121,7 +121,6 @@
     <string name="filter_close">"Закрити"</string>
     <string name="filter_reset">"Скидання"</string>
     <string name="filter_apply">"Застосувати"</string>
-    <string name="filter_ssid_title">"SSID (чутливий до регістру)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi діапазон"</string>
     <string name="filter_strength_title">"Рівень сигналу"</string>
     <string name="filter_security_title">"Безпека"</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -122,7 +122,6 @@
     <string name="filter_close">"關閉"</string>
     <string name="filter_reset">"重設"</string>
     <string name="filter_apply">"套用"</string>
-    <string name="filter_ssid_title">"SSID (區分大小寫)"</string>
     <string name="filter_wifi_band_title">"Wi-Fi 頻段"</string>
     <string name="filter_strength_title">"訊號強度"</string>
     <string name="filter_security_title">"安全"</string>


### PR DESCRIPTION
…rated

this is hard to find out now because we're using git blame basically, but SSID (case-sensitive) is unmodified in most, and there no next commits

some of it may have been lost to some 'translation cleanup' commits

there's a lot in fastlane/ though.
