### PR TITLE
Implement Black theme with black background

### DIFF
--- a/app/build.properties
+++ b/app/build.properties
@@ -1,7 +1,7 @@
 #Build Properties
-#Sat Jul 19 09:27:24 EDT 2025
-version_build=14
-version_major=3
+#Mon Jul 21 17:28:45 CEST 2025
 version_minor=2
-version_patch=1
 version_store=70
+version_patch=1
+version_build=17
+version_major=3

--- a/app/build.properties
+++ b/app/build.properties
@@ -1,7 +1,7 @@
 #Build Properties
-#Mon Jul 21 17:28:45 CEST 2025
-version_minor=2
-version_store=70
-version_patch=1
-version_build=17
+#Mon Jul 21 18:30:25 CEST 2025
+version_build=18
 version_major=3
+version_minor=2
+version_patch=1
+version_store=70

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/settings/ThemeStyle.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/settings/ThemeStyle.kt
@@ -25,6 +25,6 @@ import com.vrem.wifianalyzer.R
 enum class ThemeStyle(@param:StyleRes val theme: Int, @param:StyleRes val themeNoActionBar: Int, @param:ColorInt val colorGraphText: Int) {
     DARK(R.style.ThemeDark, R.style.ThemeDarkNoActionBar, Color.WHITE),
     LIGHT(R.style.ThemeLight, R.style.ThemeLightNoActionBar, Color.BLACK),
-    AMOLED(R.style.ThemeAmoled, R.style.ThemeAmoledNoActionBar, Color.WHITE),
+    BLACK(R.style.ThemeBlack, R.style.ThemeBlackNoActionBar, Color.WHITE),
     SYSTEM(R.style.ThemeSystem, R.style.ThemeSystemNoActionBar, Color.GRAY);
 }

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/settings/ThemeStyle.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/settings/ThemeStyle.kt
@@ -25,5 +25,6 @@ import com.vrem.wifianalyzer.R
 enum class ThemeStyle(@param:StyleRes val theme: Int, @param:StyleRes val themeNoActionBar: Int, @param:ColorInt val colorGraphText: Int) {
     DARK(R.style.ThemeDark, R.style.ThemeDarkNoActionBar, Color.WHITE),
     LIGHT(R.style.ThemeLight, R.style.ThemeLightNoActionBar, Color.BLACK),
+    AMOLED(R.style.ThemeAmoled, R.style.ThemeAmoledNoActionBar, Color.WHITE),
     SYSTEM(R.style.ThemeSystem, R.style.ThemeSystemNoActionBar, Color.GRAY);
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -106,7 +106,7 @@
     <string-array name="theme_array">
         <item>@string/theme_dark</item>
         <item>@string/theme_light</item>
-        <item>@string/theme_amoled</item>
+        <item>@string/theme_black</item>
         <item>@string/theme_system</item>
     </string-array>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -100,11 +100,13 @@
         <item>0</item>
         <item>1</item>
         <item>2</item>
+        <item>3</item>
     </string-array>
 
     <string-array name="theme_array">
         <item>@string/theme_dark</item>
         <item>@string/theme_light</item>
+        <item>@string/theme_amoled</item>
         <item>@string/theme_system</item>
     </string-array>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -40,4 +40,6 @@
     <color name="success">#4CAF50</color>
     <!-- background -->
     <color name="background">#616161</color>
+    <!-- black -->
+    <color name="black">#000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="theme_default" translatable="false">"0"</string>
     <string name="theme_dark">"Dark"</string>
     <string name="theme_light">"Light"</string>
+    <string name="theme_amoled">"AMOLED"</string>
     <string name="theme_system">"System"</string>
 
     <string name="wifi_off_on_exit_title">"Wi-Fi off on Exit"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,7 @@
     <string name="theme_default" translatable="false">"0"</string>
     <string name="theme_dark">"Dark"</string>
     <string name="theme_light">"Light"</string>
-    <string name="theme_amoled">"AMOLED"</string>
+    <string name="theme_black">"Black"</string>
     <string name="theme_system">"System"</string>
 
     <string name="wifi_off_on_exit_title">"Wi-Fi off on Exit"</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,8 +41,8 @@
     <style name="ThemeBlack" parent="Theme.AppCompat">
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:actionMenuTextColor">@color/selected</item>
-        <item name="android:windowBackground">@android:color/black</item>
-        <item name="colorPrimary">@android:color/black</item>
+        <item name="android:windowBackground">@color/black</item>
+        <item name="colorPrimary">@color/black</item>
 
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -38,6 +38,19 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="ThemeAmoled" parent="Theme.AppCompat">
+        <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
+        <item name="android:actionMenuTextColor">@color/selected</item>
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="colorPrimary">@android:color/black</item>
+
+    </style>
+
+    <style name="ThemeAmoledNoActionBar" parent="ThemeAmoled">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
     <style name="ThemeSystem" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:actionMenuTextColor">@color/selected</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -38,7 +38,7 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="ThemeAmoled" parent="Theme.AppCompat">
+    <style name="ThemeBlack" parent="Theme.AppCompat">
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:actionMenuTextColor">@color/selected</item>
         <item name="android:windowBackground">@android:color/black</item>
@@ -46,7 +46,7 @@
 
     </style>
 
-    <style name="ThemeAmoledNoActionBar" parent="ThemeAmoled">
+    <style name="ThemeBlackNoActionBar" parent="ThemeBlack">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/settings/SettingsTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/settings/SettingsTest.kt
@@ -159,7 +159,19 @@ class SettingsTest {
     }
 
     @Test
-    fun themeStyle() {
+    fun themeStyleDark() {
+        // setup
+        doReturn(ThemeStyle.DARK.ordinal)
+            .whenever(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+        // execute
+        val actual = fixture.themeStyle()
+        // validate
+        assertThat(actual).isEqualTo(ThemeStyle.DARK)
+        verify(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+    }
+
+    @Test
+    fun themeStyleLight() {
         // setup
         doReturn(ThemeStyle.LIGHT.ordinal)
             .whenever(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
@@ -167,6 +179,42 @@ class SettingsTest {
         val actual = fixture.themeStyle()
         // validate
         assertThat(actual).isEqualTo(ThemeStyle.LIGHT)
+        verify(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+    }
+
+    @Test
+    fun themeStyleBlack() {
+        // setup
+        doReturn(ThemeStyle.BLACK.ordinal)
+            .whenever(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+        // execute
+        val actual = fixture.themeStyle()
+        // validate
+        assertThat(actual).isEqualTo(ThemeStyle.BLACK)
+        verify(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+    }
+
+    @Test
+    fun themeStyleSystem() {
+        // setup
+        doReturn(ThemeStyle.SYSTEM.ordinal)
+            .whenever(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+        // execute
+        val actual = fixture.themeStyle()
+        // validate
+        assertThat(actual).isEqualTo(ThemeStyle.SYSTEM)
+        verify(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+    }
+
+    @Test
+    fun themeStyleInvalid() {
+        // setup
+        doReturn(ThemeStyle.entries.size)
+            .whenever(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
+        // execute
+        val actual = fixture.themeStyle()
+        // validate
+        assertThat(actual).isEqualTo(ThemeStyle.DARK)
         verify(repository).stringAsInteger(R.string.theme_key, ThemeStyle.DARK.ordinal)
     }
 

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/settings/ThemeStyleTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/settings/ThemeStyleTest.kt
@@ -25,13 +25,14 @@ import org.junit.Test
 class ThemeStyleTest {
     @Test
     fun themeStyle() {
-        assertThat(ThemeStyle.entries).hasSize(3)
+        assertThat(ThemeStyle.entries).hasSize(4)
     }
 
     @Test
     fun theme() {
         assertThat(ThemeStyle.LIGHT.theme).isEqualTo(R.style.ThemeLight)
         assertThat(ThemeStyle.DARK.theme).isEqualTo(R.style.ThemeDark)
+        assertThat(ThemeStyle.BLACK.theme).isEqualTo(R.style.ThemeBlack)
         assertThat(ThemeStyle.SYSTEM.theme).isEqualTo(R.style.ThemeSystem)
     }
 
@@ -39,6 +40,7 @@ class ThemeStyleTest {
     fun themeNoActionBar() {
         assertThat(ThemeStyle.DARK.themeNoActionBar).isEqualTo(R.style.ThemeDarkNoActionBar)
         assertThat(ThemeStyle.LIGHT.themeNoActionBar).isEqualTo(R.style.ThemeLightNoActionBar)
+        assertThat(ThemeStyle.BLACK.themeNoActionBar).isEqualTo(R.style.ThemeBlackNoActionBar)
         assertThat(ThemeStyle.SYSTEM.themeNoActionBar).isEqualTo(R.style.ThemeSystemNoActionBar)
     }
 
@@ -46,6 +48,7 @@ class ThemeStyleTest {
     fun colorGraphText() {
         assertThat(ThemeStyle.DARK.colorGraphText).isEqualTo(Color.WHITE)
         assertThat(ThemeStyle.LIGHT.colorGraphText).isEqualTo(Color.BLACK)
+        assertThat(ThemeStyle.BLACK.colorGraphText).isEqualTo(Color.WHITE)
         assertThat(ThemeStyle.SYSTEM.colorGraphText).isEqualTo(Color.GRAY)
     }
 


### PR DESCRIPTION
Added an additional theme which has the window background color as well as the primary color set to black. The theme is called AMOLED since the main incentive to have such a theme is energy saving on different OLED screens which emit no light when set to black.

This closes #483 

I understand that this is probably not yet suitable for a merge so I'd like to ask what else needs to be done.

Tested on my Google Pixel 8 Pro running Android 16
