### PR TITLE
Fix navigation drawer highlighting incorrect menu item after language/theme change

### DIFF
--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -34,6 +34,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
+        android:saveEnabled="false"
         app:headerLayout="@layout/main_navigation"
         app:itemIconTint="@drawable/menu_selector"
         app:itemTextColor="@drawable/menu_selector"


### PR DESCRIPTION
## Summary
- Fix navigation drawer highlighting incorrect menu item after language/theme change
- NavigationView's auto state restoration was conflicting with app's state management

## What does this implement/fix?
- Disables NavigationView's automatic state saving/restoration by adding `android:saveEnabled="false"`
- Scope: Single line change in `app/src/main/res/layout/main_activity.xml`
- Root cause: NavigationView was restoring its checked state (e.g., SETTINGS) in `onRestoreInstanceState`, overwriting the correct state set in `onCreate` from SharedPreferences

**Before:** Change language in Settings → Activity recreates → Shows AccessPoints screen but drawer highlights Settings  
**After:** Change language in Settings → Activity recreates → Shows AccessPoints screen and drawer correctly highlights AccessPoints

## How was this tested?
- Devices / OS (e.g. Android 13 emulator, Pixel 6): Android 16 emulator
- Steps to reproduce:
  1. Open app, note current screen (e.g., Access Points)
  2. Open drawer → tap Settings
  3. Change Language to different value
  4. App recreates → verify drawer highlights Access Points (not Settings)

## Checklist (required before marking ready)
- [ ] I added or updated unit tests (see `app/src/test/`)
- [ ] I followed the project's coding style (ktlint) and formatting
- [ ] I ran lint and addressed or documented any warnings
- [ ] CI checks pass (unit tests, coverage, lint)
- [x] No sensitive data, keys, or secrets are included
