### PR TITLE
Use numbered arguments for better localization support

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Авторско право \u00A9 2015 \u002D"</string>
     <string name="channel_graph_legend_title">"Покажи легенда в графика на канала"</string>
     <string name="channel_rating_best">"Най-добри канали:"</string>
-    <string name="channel_rating_best_alternative">"%s, пробвай алтернативен Wi-Fi диапазон %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, пробвай алтернативен Wi-Fi диапазон %2$s"</string>
     <string name="channel_rating_best_none">"Няма"</string>
     <string name="channel_rating_heading_count">"Брой точки за достъп"</string>
     <string name="channel_rating_heading_number">"Номер на канала"</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Copyright \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Anzeige der Legende in Kanalübersicht"</string>
     <string name="channel_rating_best">"Beste Kanäle:"</string>
-    <string name="channel_rating_best_alternative">"%s, probiere ein anderes WLAN-Frequenzband %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, probiere ein anderes WLAN-Frequenzband %2$s"</string>
     <string name="channel_rating_best_none">"Keine"</string>
     <string name="channel_rating_heading_count">"Anzahl Access Points"</string>
     <string name="channel_rating_heading_number">"Kanal"</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Πνευματικά δικαιώματα \u00A9 2015 \u002D"</string>
     <string name="channel_graph_legend_title">"Εμφάνιση υπομνήματος γραφήματος καναλιών"</string>
     <string name="channel_rating_best">"Βέλτιστα κανάλια:"</string>
-    <string name="channel_rating_best_alternative">"%s, δοκιμάστε εναλλακτική ζώνη Wi-Fi %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, δοκιμάστε εναλλακτική ζώνη Wi-Fi %2$s"</string>
     <string name="channel_rating_best_none">"Κανένα"</string>
     <string name="channel_rating_heading_count">"Πλήθος σημείων πρόσβασης"</string>
     <string name="channel_rating_heading_number">"Αριθμός καναλιού"</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Derechos de autor \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Leyenda de Visualización de Gráfico de Canales"</string>
     <string name="channel_rating_best">"Mejores canales:"</string>
-    <string name="channel_rating_best_alternative">"%s, tratar Banda Wi-Fi alternativa %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, tratar Banda Wi-Fi alternativa %2$s"</string>
     <string name="channel_rating_best_none">"Ninguno"</string>
     <string name="channel_rating_heading_count">"Cantidad de Puntos de Acceso"</string>
     <string name="channel_rating_heading_number">"Número de Canal"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -42,7 +42,7 @@
     <string name="app_copyright">"Tous droits réservés \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Légende pour le graphique des canaux"</string>
     <string name="channel_rating_best">"Meilleurs canaux:"</string>
-    <string name="channel_rating_best_alternative">"%s, essayez une autre fréquence %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, essayez une autre fréquence %2$s"</string>
     <string name="channel_rating_best_none">"Aucun"</string>
     <string name="channel_rating_heading_count">"Nombre de points d'accès"</string>
     <string name="channel_rating_heading_number">"Numéro de canal"</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -42,7 +42,7 @@
     <string name="app_copyright">"Minden jog fenntartva \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Csatorna grafikon jelmagyarázat"</string>
     <string name="channel_rating_best">"Legjobb csatornák:"</string>
-    <string name="channel_rating_best_alternative">"%s, próbálja meg a másik Wi‑Fi sávot: %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, próbálja meg a másik Wi‑Fi sávot: %2$s"</string>
     <string name="channel_rating_best_none">"Nincs"</string>
     <string name="channel_rating_heading_count">"Hozzáférési pontok száma"</string>
     <string name="channel_rating_heading_number">"Csatorna száma"</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Copyright \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Mostra legenda grafico canali"</string>
     <string name="channel_rating_best">"Canali Migliori:"</string>
-    <string name="channel_rating_best_alternative">"%s, prova un altra banda Wi-Fi %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, prova un altra banda Wi-Fi %2$s"</string>
     <string name="channel_rating_best_none">"Nessuno"</string>
     <string name="channel_rating_heading_count">"Numero di Access Point"</string>
     <string name="channel_rating_heading_number">"Numero Canale"</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Copyright \u00A9 2015 \u002D"</string>
     <string name="channel_graph_legend_title">"チャンネルグラフの凡例の位置"</string>
     <string name="channel_rating_best">"最適なチャンネル:"</string>
-    <string name="channel_rating_best_alternative">"%s、 Wi-Fi バンドを代替して試す %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s、 Wi-Fi バンドを代替して試す %2$s"</string>
     <string name="channel_rating_best_none">"なし"</string>
     <string name="channel_rating_heading_count">"アクセスポイントの数"</string>
     <string name="channel_rating_heading_number">"チャンネルの番号"</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -42,7 +42,7 @@
     <string name="app_copyright">"Auteursrecht \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Kanaalgrafiek legendaweergave"</string>
     <string name="channel_rating_best">"Beste kanalen:"</string>
-    <string name="channel_rating_best_alternative">"%s, probeer alternatieve wifi-band %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, probeer alternatieve wifi-band %2$s"</string>
     <string name="channel_rating_best_none">"Geen"</string>
     <string name="channel_rating_heading_count">"Aantal toegangspunten"</string>
     <string name="channel_rating_heading_number">"Kanaalnummer"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Prawa autorskie \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Wyświetlanie legendy wykresu kanałów"</string>
     <string name="channel_rating_best">"Najlepsze kanały:"</string>
-    <string name="channel_rating_best_alternative">"%s, spróbuj alternatywne pasmo Wi-Fi %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, spróbuj alternatywne pasmo Wi-Fi %2$s"</string>
     <string name="channel_rating_best_none">"Brak"</string>
     <string name="channel_rating_heading_count">"Liczba punktów dostępu"</string>
     <string name="channel_rating_heading_number">"Numer kanału"</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Direitos autorais \u00A9 2015 \u002D"</string>
     <string name="channel_graph_legend_title">"Legenda do gráfico"</string>
     <string name="channel_rating_best">"Canais melhores:"</string>
-    <string name="channel_rating_best_alternative">"%s, tente a frequência de %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, tente a frequência de %2$s"</string>
     <string name="channel_rating_best_none">"Nenhum"</string>
     <string name="channel_rating_heading_count">"Redes"</string>
     <string name="channel_rating_heading_number">"Número"</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -43,7 +43,7 @@
     <string name="ap_view_title">"Ecrã de redes"</string>
     <string name="channel_graph_legend_title">"Legenda do gráfico"</string>
     <string name="channel_rating_best">"Canais melhores:"</string>
-    <string name="channel_rating_best_alternative">"%s, tente a frequência de %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, tente a frequência de %2$s"</string>
     <string name="channel_rating_best_none">"Nenhum"</string>
     <string name="channel_rating_heading_count">"Contagem de pontos de acesso"</string>
     <string name="channel_rating_heading_number">"Número"</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Авторские права \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Показать легенду графика каналa"</string>
     <string name="channel_rating_best">"Лучшие каналы:"</string>
-    <string name="channel_rating_best_alternative">"%s, попробуйте альтернативный Wi-Fi диапазон %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, попробуйте альтернативный Wi-Fi диапазон %2$s"</string>
     <string name="channel_rating_best_none">"Нет"</string>
     <string name="channel_rating_heading_count">"Число точек доступа"</string>
     <string name="channel_rating_heading_number">"Номер канала"</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"Telif Hakkı \u00A9 2015 \u002D"</string>
     <string name="channel_graph_legend_title">"Kanal Grafiği Gösterge Ekranı"</string>
     <string name="channel_rating_best">"En İyi Kanallar:"</string>
-    <string name="channel_rating_best_alternative">"%s, alternatif Wi-Fi Bandını deneyin %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, alternatif Wi-Fi Bandını deneyin %2$s"</string>
     <string name="channel_rating_best_none">"Hiçbiri"</string>
     <string name="channel_rating_heading_count">"Erişim Noktası Sayısı"</string>
     <string name="channel_rating_heading_number">"Kanal Numarası"</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -54,7 +54,7 @@
     <string name="app_copyright">"Авторські права \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"Показати легенду графіка каналу"</string>
     <string name="channel_rating_best">"Кращі канали:"</string>
-    <string name="channel_rating_best_alternative">"%s, спробуйте альтернативний діапазон Wi-Fi %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, спробуйте альтернативний діапазон Wi-Fi %2$s"</string>
     <string name="channel_rating_best_none">"Немає"</string>
     <string name="channel_rating_heading_count">"Число точок доступу"</string>
     <string name="channel_rating_heading_number">"Номер каналу"</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"版权所有 \u00A9 2015 \u002D"</string>
     <string name="channel_graph_legend_title">"信道图例显示位置"</string>
     <string name="channel_rating_best">"最佳信道："</string>
-    <string name="channel_rating_best_alternative">"%s, 尝试其他 Wi-Fi 频段 %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, 尝试其他 Wi-Fi 频段 %2$s"</string>
     <string name="channel_rating_best_none">"无"</string>
     <string name="channel_rating_heading_count">"接入点数量"</string>
     <string name="channel_rating_heading_number">"信道编号"</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -43,7 +43,7 @@
     <string name="app_copyright">"著作權 \u00A9 2015 \u002D "</string>
     <string name="channel_graph_legend_title">"頻道圖例顯示位置"</string>
     <string name="channel_rating_best">"最佳頻道："</string>
-    <string name="channel_rating_best_alternative">"%s，嘗試其他 Wi-Fi 頻段 %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s，嘗試其他 Wi-Fi 頻段 %2$s"</string>
     <string name="channel_rating_best_none">"無"</string>
     <string name="channel_rating_heading_count">"存取點計數"</string>
     <string name="channel_rating_heading_number">"頻道數"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="channel_graph_legend_summary" translatable="false">"%s"</string>
     <string name="channel_graph_legend_title">"Channel Graph Legend Display"</string>
     <string name="channel_rating_best">"Best Channels:"</string>
-    <string name="channel_rating_best_alternative">"%s, try alternative Wi-Fi Band %s"</string>
+    <string name="channel_rating_best_alternative">"%1$s, try alternative Wi-Fi Band %2$s"</string>
     <string name="channel_rating_best_none">"None"</string>
     <string name="channel_rating_heading_count">"Access Point Count"</string>
     <string name="channel_rating_heading_number">"Channel Number"</string>


### PR DESCRIPTION
## Summary
- Use numbered arguments for better localization support to reduce build warnings

