### PR TITLE
Add KDoc documentation to Cache averaging algorithm

### DIFF
--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Cache.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/scanner/Cache.kt
@@ -23,6 +23,11 @@ import com.vrem.annotation.OpenClass
 import com.vrem.util.ssid
 import com.vrem.wifianalyzer.MainContext
 
+/**
+ * Holds a [ScanResult] alongside the computed signal level average
+ * for that access point across cached scans.
+ */
+
 internal class CacheResult(
     val scanResult: ScanResult,
     val average: Int,
@@ -38,6 +43,11 @@ internal class Cache {
     private val scanResults: ArrayDeque<List<ScanResult>> = ArrayDeque(MAXIMUM)
     private var count: Int = COUNT_MIN
     var wifiInfo: WifiInfo? = null
+    
+    /**
+    * Returns one [CacheResult] per unique access point (keyed by BSSID + SSID),
+    * with the signal level averaged across all scans currently in the cache.
+    */    
 
     fun scanResults(): List<CacheResult> =
         combineCache()
@@ -46,6 +56,13 @@ internal class Cache {
                 CacheResult(element, calculate(first, element, accumulator))
             }.values
             .toList()
+
+    /**
+    * Adds a new scan batch to the front of the cache (most recent first).
+    * Evicts the oldest batch when the cache exceeds [size].
+    * Also advances the internal [count] cycle used by [calculate] when
+    * screen size is unavailable.
+    */
 
     fun add(scanResults: List<ScanResult>) {
         count = if (count >= MAXIMUM * FACTOR) COUNT_MIN else count + 1
@@ -59,6 +76,16 @@ internal class Cache {
     fun first(): List<ScanResult> = scanResults.first()
 
     fun last(): List<ScanResult> = scanResults.last()
+
+    /**
+    * Returns the number of scan batches to retain in the cache.
+    * When screen size is available, the cache depth is determined by scan speed:
+    * - scanSpeed < 2  → [MAXIMUM] (4 batches)
+    * - scanSpeed < 5  → [MAXIMUM] - 1 (3 batches)
+    * - scanSpeed < 10 → [MAXIMUM] - 2 (2 batches)
+    * - else           → [MINIMUM] (1 batch, effectively no caching)
+    * When cache is disabled or screen size is unavailable, returns [MINIMUM].
+    */
 
     fun size(): Int =
         if (sizeAvailable) {
@@ -78,6 +105,16 @@ internal class Cache {
         } else {
             MINIMUM
         }
+
+    /**
+    * Computes the signal level average for an access point across cached scans
+    * using an exponential moving average: `(previous + current) / 2`.
+    * This weights recent scans more heavily than older ones.
+    *
+    * When screen size is unavailable (e.g. small screen or restricted mode),
+    * applies an additional penalty based on the internal scan [count] cycle
+    * to further reduce perceived signal strength, clamped to [-100, 0] dBm.
+    */
 
     private fun calculate(
         first: Boolean,


### PR DESCRIPTION
Document the exponential moving average used in calculate(), the cache depth strategy in size() based on scan speed thresholds, the eviction logic in add(), and the purpose of CacheResult. No logic changes.

## Summary
- Add KDoc documentation to `Cache.kt` explaining the averaging algorithm and cache sizing strategy.
- No logic changes — documentation only.

## What does this implement/fix?
- `CacheResult`: documents purpose of the class
- `scanResults()`: documents the grouping and averaging behavior per unique access point (BSSID + SSID)
- `add()`: documents eviction strategy and internal count cycle
- `size()`: documents all scan speed thresholds and their effect on cache depth
- `calculate()`: documents the exponential moving average formula `(previous + current) / 2` and the signal penalty applied when screen size is unavailable

## Does this close any issues?
- N/A (documentation improvement)

## How was this tested?
- Platform: WSL2 / AlmaLinux 9
- Build variant: debug
- Toolchain: JDK 21 (Zulu), Gradle 9.3.1, Android SDK 36
```bash
./gradlew ktlintCheck       → BUILD SUCCESSFUL
./gradlew testDebugUnitTest → BUILD SUCCESSFUL
```

## Checklist (required before marking ready)
- [x] I added or updated unit tests (see `app/src/test/`) — N/A, documentation only
- [x] I followed the project's coding style (ktlint) and formatting
- [x] I ran lint and addressed or documented any warnings
- [x] CI checks pass (unit tests, coverage, lint)
- [x] No sensitive data, keys, or secrets are included

## Additional context
The `calculate()` method used an exponential moving average without any inline explanation,
making it non-obvious why `(accumulator + element) / 2` was chosen over a true N-sample average.
The `size()` thresholds were also implicit. This PR makes both strategies explicit for future contributors.