### PR TITLE
Add SecurityTypes column to exported CSV

### DIFF
--- a/app/src/main/kotlin/com/vrem/wifianalyzer/export/Export.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/export/Export.kt
@@ -46,7 +46,8 @@ class Export(
             "802.11mc|" +
             "Security|" +
             "Standard|" +
-            "FastRoaming" +
+            "FastRoaming|" +
+            "SecurityTypes" +
             "\n"
 
     fun export(
@@ -103,7 +104,8 @@ class Export(
                     "${wiFiSignal.extra.is80211mc}|" +
                     wiFiSecurity.capabilities + "|" +
                     wiFiSignal.extra.wiFiStandardDisplay(context) + "|" +
-                    wiFiSignal.extra.fastRoamingDisplay(context) +
+                    wiFiSignal.extra.fastRoamingDisplay(context)  + "|" +
+                    wiFiSecurity.wiFiSecurityTypesDisplay(context) +
                     "\n"
             }
         }

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/export/ExportTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/export/ExportTest.kt
@@ -128,16 +128,16 @@ class ExportTest {
 
     private fun data(timestamp: String): String =
         "Time Stamp|SSID|BSSID|Strength|Primary Channel|Primary Frequency|Center Channel|Center Frequency|" +
-            "Width (Range)|Distance|802.11mc|Security|Standard|FastRoaming\n" +
+            "Width (Range)|Distance|802.11mc|Security|Standard|FastRoaming|SecurityTypes\n" +
             timestamp +
             "|SSID10|BSSID10|-10dBm|3|2422MHz|5|2432MHz|40MHz (2412 - 2452)|~0.0m|true|capabilities10|802.11AC|" +
-            "802.11R\n" +
+            "802.11R|[]\n" +
             timestamp +
             "|SSID20|BSSID20|-20dBm|5|2432MHz|7|2442MHz|40MHz (2422 - 2462)|~0.1m|true|capabilities20|802.11AC|" +
-            "802.11R\n" +
+            "802.11R|[]\n" +
             timestamp +
             "|SSID30|BSSID30|-30dBm|7|2442MHz|9|2452MHz|40MHz (2432 - 2472)|~0.3m|true|capabilities30|802.11AC|" +
-            "802.11R\n"
+            "802.11R|[]\n"
 
     private fun timestamp(date: Date): String = SimpleDateFormat("yyyy/MM/dd-HH:mm:ss", Locale.US).format(date)
 


### PR DESCRIPTION
Include wiFiSecurityTypesDisplay in the export output as a new SecurityTypes column. This exposes the structured security type information (e.g. [SAE OWE]) already available in the model but missing from the exported data.

## Summary
- Add `SecurityTypes` column to the exported CSV output.
- The structured security type information (e.g. `[SAE OWE]`) was already available in the model via `wiFiSecurityTypesDisplay` but was not included in the export.

## What does this implement/fix?
- `Export.kt`: added `SecurityTypes` header column and `wiFiSecurityTypesDisplay(context)` field to each exported row
- `ExportTest.kt`: updated expected header and all data rows to include the new column

## Does this close any issues?
- N/A (data completeness improvement)

## How was this tested?
- Platform: WSL2 / AlmaLinux 9
- Build variant: debug
- Toolchain: JDK 21 (Zulu), Gradle 9.3.1, Android SDK 36
```bash
./gradlew ktlintCheck                                              → BUILD SUCCESSFUL
./gradlew testDebugUnitTest                                        → BUILD SUCCESSFUL (3432 tests)
./gradlew testDebugUnitTest --tests "com.vrem.wifianalyzer.export.ExportTest" → BUILD SUCCESSFUL
```

## Checklist (required before marking ready)
- [x] I added or updated unit tests (see `app/src/test/`)
- [x] I followed the project's coding style (ktlint) and formatting
- [x] I ran lint and addressed or documented any warnings
- [x] CI checks pass (unit tests, coverage, lint)
- [x] No sensitive data, keys, or secrets are included

## Additional context
The export already included raw `capabilities` (e.g. `[WPA2-PSK-CCMP][ESS]`) as the `Security` column.
The new `SecurityTypes` column adds the resolved structured representation available from Android 13+
(e.g. `[SAE OWE]`), making the export more useful for analysis on modern devices.
On devices running Android 12 or earlier the column will contain `[]` as `securityTypes` is not populated.
