### PR TITLE
fix: Filtered SSIDs persist in time graph legend

### DIFF
--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/timegraph/DataManager.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/timegraph/DataManager.kt
@@ -25,6 +25,7 @@ import com.vrem.wifianalyzer.wifi.graphutils.MAX_SCAN_COUNT
 import com.vrem.wifianalyzer.wifi.graphutils.MIN_Y
 import com.vrem.wifianalyzer.wifi.graphutils.MIN_Y_OFFSET
 import com.vrem.wifianalyzer.wifi.model.WiFiDetail
+import com.vrem.wifianalyzer.wifi.predicate.Predicate
 
 @OpenClass
 internal class DataManager(
@@ -37,10 +38,11 @@ internal class DataManager(
         graphViewWrapper: GraphViewWrapper,
         wiFiDetails: List<WiFiDetail>,
         levelMax: Int,
+        predicate: Predicate,
     ): Set<WiFiDetail> {
         val inOrder: Set<WiFiDetail> = wiFiDetails.toSet()
         inOrder.forEach { addData(graphViewWrapper, it, levelMax) }
-        adjustData(graphViewWrapper, inOrder)
+        adjustData(graphViewWrapper, inOrder, predicate)
         xValue++
         if (scanCount < MAX_SCAN_COUNT) {
             scanCount++
@@ -48,23 +50,30 @@ internal class DataManager(
         if (scanCount == 2) {
             graphViewWrapper.setHorizontalLabelsVisible(true)
         }
-        return newSeries(inOrder)
+        return newSeries(inOrder, predicate)
     }
 
     fun adjustData(
         graphViewWrapper: GraphViewWrapper,
         wiFiDetails: Set<WiFiDetail>,
+        predicate: Predicate,
     ) {
-        graphViewWrapper.differenceSeries(wiFiDetails).forEach {
-            val dataPoint = GraphDataPoint(xValue, MIN_Y + MIN_Y_OFFSET)
-            val drawBackground = it.wiFiAdditional.wiFiConnection.connected
-            graphViewWrapper.appendToSeries(it, dataPoint, scanCount, drawBackground)
-            timeGraphCache.add(it)
-        }
+        graphViewWrapper
+            .differenceSeries(wiFiDetails)
+            .filter { predicate(it) }
+            .forEach {
+                val dataPoint = GraphDataPoint(xValue, MIN_Y + MIN_Y_OFFSET)
+                val drawBackground = it.wiFiAdditional.wiFiConnection.connected
+                graphViewWrapper.appendToSeries(it, dataPoint, scanCount, drawBackground)
+                timeGraphCache.add(it)
+            }
         timeGraphCache.clear()
     }
 
-    fun newSeries(wiFiDetails: Set<WiFiDetail>): Set<WiFiDetail> = wiFiDetails.plus(timeGraphCache.active())
+    fun newSeries(
+        wiFiDetails: Set<WiFiDetail>,
+        predicate: Predicate,
+    ): Set<WiFiDetail> = wiFiDetails.plus(timeGraphCache.active().filter { predicate(it) })
 
     fun addData(
         graphViewWrapper: GraphViewWrapper,

--- a/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/timegraph/TimeGraphView.kt
+++ b/app/src/main/kotlin/com/vrem/wifianalyzer/wifi/timegraph/TimeGraphView.kt
@@ -70,6 +70,7 @@ internal class TimeGraphView(
                 graphViewWrapper,
                 wiFiDetails,
                 MainContext.INSTANCE.settings.graphMaximumY(),
+                predicate,
             )
         graphViewWrapper.removeSeries(newSeries)
         graphViewWrapper.updateLegend(MainContext.INSTANCE.settings.timeGraphLegend())

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/timegraph/DataManagerTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/timegraph/DataManagerTest.kt
@@ -156,6 +156,47 @@ class DataManagerTest {
     }
 
     @Test
+    fun newSeriesShouldNotIncludeActiveCacheEntriesNotInCurrentWiFiDetails() {
+        // Expected: newSeries includes currentDetails and only those active cache
+        // entries that satisfy the given predicate. Entries from timeGraphCache.active()
+        // that do not match the predicate (e.g. filtered-out SSIDs) must be excluded.
+        // setup
+        val currentDetails: Set<WiFiDetail> = makeWiFiDetails().toSet()
+        val staleEntries: Set<WiFiDetail> = makeMoreWiFiDetails().toSet()
+        whenever(timeGraphCache.active()).thenReturn(staleEntries)
+        // execute
+        val actual = fixture.newSeries(currentDetails)
+        // validate: current entries must be present, stale entries must NOT leak in
+        assertThat(actual).containsAll(currentDetails)
+        assertThat(actual).doesNotContainAnyElementsOf(staleEntries)
+        verify(timeGraphCache).active()
+    }
+
+    @Test
+    fun adjustDataShouldNotAppendToStaleCacheEntriesNotInCurrentDetails() {
+        // Expected: adjustData only appends floor data points and increments the
+        // TimeGraphCache counter for differenceSeries entries that satisfy the
+        // given predicate. Entries that do not match must be left untouched.
+        // setup
+        val currentDetails: Set<WiFiDetail> = makeWiFiDetails().toSet()
+        val staleEntry: WiFiDetail = makeWiFiDetail("SSID4")
+        whenever(graphViewWrapper.differenceSeries(currentDetails))
+            .thenReturn(listOf(staleEntry))
+        // execute
+        fixture.adjustData(graphViewWrapper, currentDetails)
+        // validate: stale entries must NOT receive floor data points
+        verify(graphViewWrapper, never()).appendToSeries(
+            eq(staleEntry),
+            any(),
+            any(),
+            any(),
+        )
+        // validate: stale entries must NOT be added to the time graph cache
+        verify(timeGraphCache, never()).add(staleEntry)
+        verify(timeGraphCache).clear()
+    }
+
+    @Test
     fun addDataToExistingSeries() {
         // setup
         val scanCount = fixture.scanCount

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/timegraph/DataManagerTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/timegraph/DataManagerTest.kt
@@ -33,6 +33,8 @@ import com.vrem.wifianalyzer.wifi.model.WiFiIdentifier
 import com.vrem.wifianalyzer.wifi.model.WiFiSecurity
 import com.vrem.wifianalyzer.wifi.model.WiFiSignal
 import com.vrem.wifianalyzer.wifi.model.WiFiWidth
+import com.vrem.wifianalyzer.wifi.predicate.falsePredicate
+import com.vrem.wifianalyzer.wifi.predicate.truePredicate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -59,7 +61,7 @@ class DataManagerTest {
         // setup
         assertThat(fixture.xValue).isEqualTo(0)
         // execute
-        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y)
+        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y, truePredicate)
         // validate
         assertThat(fixture.xValue).isEqualTo(1)
     }
@@ -69,7 +71,7 @@ class DataManagerTest {
         // setup
         assertThat(fixture.scanCount).isEqualTo(0)
         // execute
-        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y)
+        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y, truePredicate)
         // validate
         assertThat(fixture.scanCount).isEqualTo(1)
     }
@@ -80,7 +82,7 @@ class DataManagerTest {
         val wiFiDetails = makeWiFiDetails()
         val wiFiDetailsSet = wiFiDetails.toSet()
         // execute
-        fixture.addSeriesData(graphViewWrapper, wiFiDetails, MAX_Y)
+        fixture.addSeriesData(graphViewWrapper, wiFiDetails, MAX_Y, truePredicate)
         // validate
         wiFiDetailsSet.forEach {
             verify(graphViewWrapper).newSeries(it)
@@ -93,7 +95,7 @@ class DataManagerTest {
         // setup
         fixture.scanCount = MAX_SCAN_COUNT
         // execute
-        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y)
+        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y, truePredicate)
         // validate
         assertThat(fixture.scanCount).isEqualTo(MAX_SCAN_COUNT)
     }
@@ -103,7 +105,7 @@ class DataManagerTest {
         // setup
         fixture.scanCount = 1
         // execute
-        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y)
+        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y, truePredicate)
         // validate
         assertThat(fixture.scanCount).isEqualTo(2)
         verify(graphViewWrapper).setHorizontalLabelsVisible(true)
@@ -112,7 +114,7 @@ class DataManagerTest {
     @Test
     fun addSeriesDoesNotSetHorizontalLabelsVisible() {
         // execute
-        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y)
+        fixture.addSeriesData(graphViewWrapper, listOf(), MAX_Y, truePredicate)
         // validate
         verify(graphViewWrapper, never()).setHorizontalLabelsVisible(true)
     }
@@ -127,7 +129,7 @@ class DataManagerTest {
         val dataPoint = GraphDataPoint(xValue, MIN_Y + MIN_Y_OFFSET)
         whenever(graphViewWrapper.differenceSeries(wiFiDetails)).thenReturn(difference)
         // execute
-        fixture.adjustData(graphViewWrapper, wiFiDetails)
+        fixture.adjustData(graphViewWrapper, wiFiDetails, truePredicate)
         // validate
         difference.forEach {
             verify(graphViewWrapper).appendToSeries(
@@ -148,7 +150,7 @@ class DataManagerTest {
         val moreWiFiDetails: Set<WiFiDetail> = makeMoreWiFiDetails().toSet()
         whenever(timeGraphCache.active()).thenReturn(moreWiFiDetails)
         // execute
-        val actual = fixture.newSeries(wiFiDetails)
+        val actual = fixture.newSeries(wiFiDetails, truePredicate)
         // validate
         assertThat(actual).containsAll(wiFiDetails)
         assertThat(actual).containsAll(moreWiFiDetails)
@@ -165,8 +167,7 @@ class DataManagerTest {
         val staleEntries: Set<WiFiDetail> = makeMoreWiFiDetails().toSet()
         whenever(timeGraphCache.active()).thenReturn(staleEntries)
         // execute
-        val actual = fixture.newSeries(currentDetails)
-        // validate: current entries must be present, stale entries must NOT leak in
+        val actual = fixture.newSeries(currentDetails, falsePredicate)
         assertThat(actual).containsAll(currentDetails)
         assertThat(actual).doesNotContainAnyElementsOf(staleEntries)
         verify(timeGraphCache).active()
@@ -183,8 +184,7 @@ class DataManagerTest {
         whenever(graphViewWrapper.differenceSeries(currentDetails))
             .thenReturn(listOf(staleEntry))
         // execute
-        fixture.adjustData(graphViewWrapper, currentDetails)
-        // validate: stale entries must NOT receive floor data points
+        fixture.adjustData(graphViewWrapper, currentDetails, falsePredicate)
         verify(graphViewWrapper, never()).appendToSeries(
             eq(staleEntry),
             any(),

--- a/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/timegraph/TimeGraphViewTest.kt
+++ b/app/src/test/kotlin/com/vrem/wifianalyzer/wifi/timegraph/TimeGraphViewTest.kt
@@ -70,7 +70,7 @@ class TimeGraphViewTest {
         val wiFiData = WiFiData(wiFiDetails, WiFiConnection.EMPTY)
         val predicate: Predicate = truePredicate
         doReturn(predicate).whenever(fixture).predicate(settings)
-        whenever(dataManager.addSeriesData(graphViewWrapper, wiFiDetails, MAX_Y)).thenReturn(newSeries)
+        whenever(dataManager.addSeriesData(graphViewWrapper, wiFiDetails, MAX_Y, predicate)).thenReturn(newSeries)
         whenever(settings.sortBy()).thenReturn(SortBy.SSID)
         whenever(settings.timeGraphLegend()).thenReturn(GraphLegend.LEFT)
         whenever(settings.wiFiBand()).thenReturn(WiFiBand.GHZ2)
@@ -80,7 +80,7 @@ class TimeGraphViewTest {
         fixture.update(wiFiData)
         // validate
         verify(fixture).predicate(settings)
-        verify(dataManager).addSeriesData(graphViewWrapper, wiFiDetails, MAX_Y)
+        verify(dataManager).addSeriesData(graphViewWrapper, wiFiDetails, MAX_Y, predicate)
         verify(graphViewWrapper).removeSeries(newSeries)
         verify(graphViewWrapper).updateLegend(GraphLegend.LEFT)
         verify(graphViewWrapper).visibility(View.VISIBLE)


### PR DESCRIPTION
## Summary
- Adds two failing unit tests that expose a bug where filtered-out SSIDs persist in the time graph legend after enabling a filter directly from the time graph screen.
- These tests are first committed as TDD RED before the fix.

## What does this implement/fix?
This PR adds two test cases in `DataManagerTest.kt` that fail:
- `newSeriesShouldNotIncludeActiveCacheEntriesNotInCurrentWiFiDetails` -- verifies that `newSeries()` excludes cached entries that do not match the applied filter predicate.
- `adjustDataShouldNotAppendToStaleCacheEntriesNotInCurrentDetails` -- verifies that `adjustData()` does not append floor-level data points or increment TimeGraphCache counters for entries that do not match the predicate.

The bug: when a user navigates directly to the time graph and enables an SSID filter, `DataManager.newSeries()` unconditionally merges `timeGraphCache.active()` entries into the return set. Since `removeSeries()` only removes series not in this set, filtered-out SSIDs remain visible for up to `MAX_NOT_SEEN_COUNT` (20) scans.

## Does this close any issues?
None.

## How was this tested?
- Devices / OS (e.g. Android 13 emulator, Pixel 6): Android 15 and Unit tests
- Platform / Build variant (e.g. debug/release): debug
- Toolchain / Gradle / SDK version(s): Kotlin 2.3.20, AGP 9.1.1, Gradle 9.4.1
- Steps to reproduce / test (provide exact steps so reviewers can verify): Time Graph -> Apply Filter -> See the SSIDs that should be filtered out are still in the legend.

## Checklist (required before marking ready)
- [x] I added or updated unit tests (see `app/src/test/`)
- [x] I followed the project's coding style (ktlint) and formatting
- [x] I ran lint and addressed or documented any warnings
- [x] CI checks pass (unit tests, coverage, lint)
- [x] No sensitive data, keys, or secrets are included

## AI Assistance
- [x] AI tools were used (Copilot, ChatGPT, Claude, etc.) — please add the **“AI assistance used”** label.
- [ ] No AI tools were used

## Additional context
None.

## Reviewer notes
None.